### PR TITLE
Macro to disable RTTI

### DIFF
--- a/src/cxxopts.hpp
+++ b/src/cxxopts.hpp
@@ -500,7 +500,11 @@ namespace cxxopts
     const T&
     as() const
     {
+#ifdef CXXOPTS_NO_RTTI
+      return static_cast<const values::default_value<T>&>(*m_value).get();
+#else
       return dynamic_cast<const values::default_value<T>&>(*m_value).get();
+#endif
     }
 
     private:


### PR DESCRIPTION
This patch adds support for compiling without rtti (-fno-rtti) by adding a macro to replace dynamic_cast with static_cast. 

static_cast is enough to perform a downcast, but it will not perform a runtime check, therefore it should only be activated when the user is sure of what he does. 
