### PR TITLE
Fix remaining character check

### DIFF
--- a/src/cxxopts.hpp
+++ b/src/cxxopts.hpp
@@ -387,7 +387,7 @@ namespace cxxopts
         throw argument_incorrect_type(text);
       }
 
-      if (!is.eof())
+      if (is.rdbuf()->in_avail() != 0)
       {
         throw argument_incorrect_type(text);
       }


### PR DESCRIPTION
I wanted to use a 'char' argument (cxxopts::value<char>()) but I always got an exception.
error parsing options: Argument ‘a’ failed to parse

The istringstream::eof function will return true when a read operation attempts to read beyond end of file, but not when it reads exactly to the end of file without trying to go further. When you read the char, it knows it should read a single byte, so this read operation is ok, the read position advance 1 byte, goes to the end, but let say the the stream still haven't noticed that it is indeed the end, it will if you try to read something else.
So if you want to check that there is no more available character to read you can't use the istringstream::eof function, you have to use streambuf::in_avail function instead of the istringstream::eof function.


