### PR TITLE
Better support for spaces

### DIFF
--- a/src/cxxopts.hpp
+++ b/src/cxxopts.hpp
@@ -410,6 +410,13 @@ namespace cxxopts
       //so that we can write --long=yes explicitly
       value = true;
     }
+    
+    inline
+    void
+    parse_value(const std::string& text, std::string& value)
+    {
+      value = text;
+    }
 
     template <typename T>
     struct value_has_arg


### PR DESCRIPTION
This PR fixes support for options such as --file="folder with spaces/file".

However, I don't think that all the cases are covered, but at least the very simple case of an argument with space is covered. 

What do you think of it ? 