### PR TITLE
Remove log output

### DIFF
--- a/src/cxxopts.hpp
+++ b/src/cxxopts.hpp
@@ -391,7 +391,6 @@ namespace cxxopts
       std::istringstream is(text);
       if (!(is >> value))
       {
-        std::cerr << "cannot parse empty value" << std::endl;
         throw argument_incorrect_type(text);
       }
 


### PR DESCRIPTION
Looked like it was left over from something? Saw it when testing "--some-int-val string"