### PR TITLE
Don't count default values

### DIFF
--- a/src/cxxopts.hpp
+++ b/src/cxxopts.hpp
@@ -609,7 +609,6 @@ namespace cxxopts
     parse_default()
     {
       m_value->parse();
-      ++m_count;
     }
 
     int


### PR DESCRIPTION
This makes option parsing of something like this possible:

```cpp
  m_options.add_options()
    ("output-file", "Output filename", cxxopts::value(m_outputFile))
    ("output-format", "Output format", cxxopts::value(m_outputFormat)->default_value("csv"))
    ;

  m_options.parse(argc, argv);
  if (!m_options.count("metadata-format"))
  {
    // output format not specified explicitly - try to figure it out
    // implicitly by m_outputFile extension
    // ...
  }
```