### PR TITLE
Update CMakeLists to be more configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ project(cxxopts)
 
 set(VERSION "0.0.1")
 
+option(CXXOPTS_BUILD_EXAMPLES "Set to ON to build examples" ON)
+
 set(CXXOPTS_LINKER_LIBRARIES "")
 
 set(CXXOPTS_USE_UNICODE_HELP FALSE CACHE BOOL "Use ICU Unicode library")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_executable(example example.cpp)
+if(CXXOPTS_BUILD_EXAMPLES)
+	add_executable(example example.cpp cxxopts.hpp)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
-target_link_libraries(example ${CXXOPTS_LINKER_LIBRARIES})
+	if (MSVC)
+		target_compile_options(example PUBLIC /W2)
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		target_compile_options(example PUBLIC -std=c++11 -Wall)
+	endif()
+endif()
 
 install(FILES cxxopts.hpp DESTINATION include)


### PR DESCRIPTION
* Add cxxopts.hpp as a source file to executable
* Add msvc options for compiling
* Add CXXOPTS_BUILD_EXAMPLES option to CMake build
  * This is helpful when using CMake's ExternalProject_add()
  * It is ON by default, but configurable from the command-line.