### PR TITLE
Interpret input starting with 0x as hex numbers.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -404,9 +404,17 @@ namespace cxxopts
     parse_value(const std::string& text, T& value)
     {
       std::istringstream is(text);
-      if (!(is >> value))
-      {
-        throw argument_incorrect_type(text);
+      if (text.substr(0, 2) == "0x"){ //Hex number input
+        is.seekg(2);
+        if (!(is >> std::hex >> value))
+        {
+           throw argument_incorrect_type(text);
+        }
+      } else {
+        if (!(is >> value))
+        {
+           throw argument_incorrect_type(text);
+        }
       }
 
       if (is.rdbuf()->in_avail() != 0)


### PR DESCRIPTION
When giving numeric values are hex (0xF00) cxxopts will currently refuse these.
This patch will check for 0x prefix and parse the value as hex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/40)
<!-- Reviewable:end -->
