### PR TITLE
Conditionally output all help groups on empty groups vector

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -793,6 +793,14 @@ namespace cxxopts
     String
     help_one_group(const std::string& group) const;
 
+  inline
+  void
+  generate_group_help(String& result, const std::vector<std::string>& groups) const;
+
+  inline
+  void
+  generate_all_groups_help(String& result) const;
+
     std::string m_program;
     String m_help_string;
 
@@ -1362,6 +1370,35 @@ Options::help_one_group(const std::string& g) const
   return result;
 }
 
+void
+Options::generate_group_help(String& result, const std::vector<std::string>& groups) const
+{
+  for (std::size_t i = 0; i < groups.size(); ++i)
+  {
+    String const& group_help = help_one_group(groups[i]);
+  if (empty(group_help)) continue;
+    result += group_help;
+    if (i < groups.size() - 1)
+  {
+    result += '\n';
+  }
+  }
+}
+
+void
+Options::generate_all_groups_help(String& result) const
+{
+  std::vector<std::string> groups;
+  groups.reserve(m_help.size());
+
+  for (auto& group : m_help)
+  {
+  groups.push_back(group.first);
+  }
+
+  generate_group_help(result, groups);
+}
+
 std::string
 Options::help(const std::vector<std::string>& groups) const
 {
@@ -1374,15 +1411,13 @@ Options::help(const std::vector<std::string>& groups) const
 
   result += "\n\n";
 
-  for (std::size_t i = 0; i < groups.size(); ++i)
+  if (groups.size() == 0)
   {
-    String const& group_help = help_one_group(groups[i]);
-    if (empty(group_help)) continue;
-    result += group_help;
-    if (i < groups.size() - 1)
-    {
-      result += '\n';
-    }
+    generate_all_groups_help(result);
+  }
+  else
+  {
+    generate_group_help(result, groups);
   }
 
   return toUTF8String(result);

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1376,12 +1376,12 @@ Options::generate_group_help(String& result, const std::vector<std::string>& gro
   for (std::size_t i = 0; i < groups.size(); ++i)
   {
     String const& group_help = help_one_group(groups[i]);
-  if (empty(group_help)) continue;
+    if (empty(group_help)) continue;
     result += group_help;
     if (i < groups.size() - 1)
-  {
-    result += '\n';
-  }
+    {
+      result += '\n';
+    }
   }
 }
 
@@ -1393,7 +1393,7 @@ Options::generate_all_groups_help(String& result) const
 
   for (auto& group : m_help)
   {
-  groups.push_back(group.first);
+    groups.push_back(group.first);
   }
 
   generate_group_help(result, groups);


### PR DESCRIPTION
I wanted to output all groups using the `help()` method without specifying them all manually.
As I couldn't find this feature in the current code, I just added this feature.

I decided to just use an empty `groups` vector as the condition to output all help groups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/42)
<!-- Reviewable:end -->
