### PR TITLE
Added inline to check_required

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -858,6 +858,7 @@ namespace cxxopts
   };
 
   // A helper function for setting required arguments
+  inline
   void
   check_required
   (


### PR DESCRIPTION
This alleviated an issue I had where during compilation, check_required was defined multiple times. It looked like the only function that did not have the inline modifier before it, which explains why it was the only one to be defined multiple times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/51)
<!-- Reviewable:end -->
