### PR TITLE
Fixup integer pattern multiple definition

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -428,11 +428,6 @@ namespace cxxopts
 
   namespace values
   {
-    namespace
-    {
-      std::basic_regex<char> integer_pattern
-        ("(-)?(0x)?([1-9a-zA-Z][0-9a-zA-Z]*)|(0)");
-    }
 
     namespace detail
     {
@@ -484,6 +479,8 @@ namespace cxxopts
     integer_parser(const std::string& text, T& value)
     {
       std::smatch match;
+      std::basic_regex<char> integer_pattern
+        ("(-)?(0x)?([1-9a-zA-Z][0-9a-zA-Z]*)|(0)");
       std::regex_match(text, match, integer_pattern);
 
       if (match.length() == 0)


### PR DESCRIPTION
Fixes #69 

Since the value was only used once, I did not need to make a singleton as initially proposed in #69.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/70)
<!-- Reviewable:end -->
