### PR TITLE
avoid warning about non-virtual destructor

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -694,7 +694,7 @@ namespace cxxopts
     };
 
     template <typename T>
-    class standard_value : public Value
+    class standard_value final : public Value
     {
       public:
       standard_value()


### PR DESCRIPTION
´Value´ and ´standard_value´ don't have a virtual destructor. When I understand the code right, this is intended, because they are used through ´shared_ptr´ and so its not required. Nevertheless, clang does warn about it, since at the point of the destructor call it can not check if the object has a final type. Adding the C++11 keyword ´final´ to ´standard_value´ avoids this warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/75)
<!-- Reviewable:end -->
