### PR TITLE
Accidentally disables -Wnon-virtual-dtor for unrelated code

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1744,7 +1744,7 @@ Options::group_help(const std::string& group) const
 
 }
 
-#if defined(__GNU__)
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
The top of the file tests for \_\_GNUC\_\_ to disable -Wnon-virtual-dtor.

The bottom of the file tries to test for \_\_GNUC\_\_ to reset that warning to the default state. Unfortunately, it's typoed as \_\_GNU\_\_, which doesn't exist, so the warning is left disabled.

Simple typo, simple fix.

(surprised that gcc doesn't throw a warning that the warning stack isn't empty, but oh well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/79)
<!-- Reviewable:end -->
