### PR TITLE
Compile warning fixes

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -566,7 +566,7 @@ namespace cxxopts
           throw argument_incorrect_type(text);
         }
 
-        result = result * base + digit;
+        result = static_cast<US>(result * base + digit);
       }
 
       detail::check_signed_range<T>(negative, result, text);
@@ -1091,7 +1091,7 @@ namespace cxxopts
 
       auto riter = m_results.find(iter->second);
 
-      return riter->second.count();
+      return static_cast<int>(riter->second.count());
     }
 
     const OptionValue&


### PR DESCRIPTION
My build settings are set to treat warnings as error, so I had to fix a couple of warnings in this library.  The changes are minor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/81)
<!-- Reviewable:end -->
