### PR TITLE
`|` should be inside of `(…)`

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -446,7 +446,7 @@ namespace cxxopts
       std::basic_regex<char> truthy_pattern
         ("(t|T)(rue)?");
       std::basic_regex<char> falsy_pattern
-        ("(f|false|F|False)?");
+        ("((f|F)(alse)?)?");
     }
 
     namespace detail
@@ -1570,7 +1570,7 @@ ParseResult::consume_positional(std::string a)
     if (iter != m_options.end())
     {
       auto& result = m_results[iter->second];
-      if (!iter->second->value().is_container()) 
+      if (!iter->second->value().is_container())
       {
         if (result.count() == 0)
         {

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -444,7 +444,7 @@ namespace cxxopts
       std::basic_regex<char> integer_pattern
         ("(-)?(0x)?([1-9a-zA-Z][0-9a-zA-Z]*)|((0x)?0)");
       std::basic_regex<char> truthy_pattern
-        ("t|true|T|True");
+        ("(t|T)(rue)?");
       std::basic_regex<char> falsy_pattern
         ("(f|false|F|False)?");
     }


### PR DESCRIPTION
It's possible to use `(t|true|T|True)` as `truthy_pattern` but still failing `true` as a truthy under my environment :-(

```
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

\# clang-5.0.0 works as expected even if does not modify it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/87)
<!-- Reviewable:end -->
