### PR TITLE
fixed “possible loss of data” warning on Visual Studio

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1080,7 +1080,7 @@ namespace cxxopts
       std::vector<std::string>,
       int&, char**&);
 
-    int
+    size_t
     count(const std::string& o) const
     {
       auto iter = m_options.find(o);


### PR DESCRIPTION
`int` and `size_t` are different sizes on Windows, which generates a warning in Visual Studio. There's seems no reason NOT to return a `size_t` here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/89)
<!-- Reviewable:end -->
