### PR TITLE
Add default "default" value to boolean options

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -855,13 +855,13 @@ namespace cxxopts
 
       standard_value()
       {
-        set_implicit();
+        set_default_and_implicit();
       }
 
       standard_value(bool* b)
       : abstract_value(b)
       {
-        set_implicit();
+        set_default_and_implicit();
       }
 
       std::shared_ptr<Value>
@@ -873,8 +873,10 @@ namespace cxxopts
       private:
 
       void
-      set_implicit()
+      set_default_and_implicit()
       {
+        m_default = true;
+        m_default_value = "false";
         m_implicit = true;
         m_implicit_value = "true";
       }

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -423,6 +423,9 @@ TEST_CASE("Booleans", "[boolean]") {
     ("bool", "A Boolean", cxxopts::value<bool>())
     ("debug", "Debugging", cxxopts::value<bool>())
     ("timing", "Timing", cxxopts::value<bool>())
+    ("noExplicitDefault", "No Explicit Default", cxxopts::value<bool>())
+    ("defaultTrue", "Timing", cxxopts::value<bool>()->default_value("true"))
+    ("defaultFalse", "Timing", cxxopts::value<bool>()->default_value("false"))
     ("others", "Other arguments", cxxopts::value<std::vector<std::string>>())
     ;
 
@@ -438,10 +441,16 @@ TEST_CASE("Booleans", "[boolean]") {
   REQUIRE(result.count("bool") == 1);
   REQUIRE(result.count("debug") == 1);
   REQUIRE(result.count("timing") == 1);
+  REQUIRE(result.count("noExplicitDefault") == 1);
+  REQUIRE(result.count("defaultTrue") == 1);
+  REQUIRE(result.count("defaultFalse") == 1);
 
   CHECK(result["bool"].as<bool>() == false);
   CHECK(result["debug"].as<bool>() == true);
   CHECK(result["timing"].as<bool>() == true);
+  CHECK(result["noExplicitDefault"].as<bool>() == false);
+  CHECK(result["defaultTrue"].as<bool>() == true);
+  CHECK(result["defaultFalse"].as<bool>() == false);
 
   REQUIRE(result.count("others") == 1);
 }


### PR DESCRIPTION
Add default "default" value of "false" to boolean options, therefore allowing to call `result["boolOpt"].as<bool>()` without throwing an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/94)
<!-- Reviewable:end -->
