### PR TITLE
Allow unrecognised options.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1750,6 +1750,9 @@ ParseResult::parse(int& argc, char**& argv)
         {
           if (m_allow_unrecognised)
           {
+            // keep unrecognised options in argument list, skip to next argument
+            argv[nextKeep] = argv[current];
+            ++nextKeep;
             ++current;
             continue;
           }

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1095,6 +1095,7 @@ namespace cxxopts
     ParseResult(
       const std::unordered_map<std::string, std::shared_ptr<OptionDetails>>&,
       std::vector<std::string>,
+      bool allow_unrecognised,
       int&, char**&);
 
     size_t
@@ -1174,6 +1175,8 @@ namespace cxxopts
     std::unordered_set<std::string> m_positional_set;
     std::unordered_map<std::shared_ptr<OptionDetails>, OptionValue> m_results;
 
+    bool m_allow_unrecognised;
+
     std::vector<KeyValue> m_sequential;
   };
 
@@ -1187,6 +1190,7 @@ namespace cxxopts
     , m_custom_help("[OPTION...]")
     , m_positional_help("positional parameters")
     , m_show_positional(false)
+    , m_allow_unrecognised(false)
     , m_next_positional(m_positional.end())
     {
     }
@@ -1209,6 +1213,13 @@ namespace cxxopts
     show_positional_help()
     {
       m_show_positional = true;
+      return *this;
+    }
+
+    Options&
+    allow_unrecognised_options()
+    {
+      m_allow_unrecognised = true;
       return *this;
     }
 
@@ -1275,6 +1286,7 @@ namespace cxxopts
     std::string m_custom_help;
     std::string m_positional_help;
     bool m_show_positional;
+    bool m_allow_unrecognised;
 
     std::unordered_map<std::string, std::shared_ptr<OptionDetails>> m_options;
     std::vector<std::string> m_positional;
@@ -1431,11 +1443,13 @@ ParseResult::ParseResult
 (
   const std::unordered_map<std::string, std::shared_ptr<OptionDetails>>& options,
   std::vector<std::string> positional,
+  bool allow_unrecognised,
   int& argc, char**& argv
 )
 : m_options(options)
 , m_positional(std::move(positional))
 , m_next_positional(m_positional.begin())
+, m_allow_unrecognised(allow_unrecognised)
 {
   parse(argc, argv);
 }
@@ -1641,7 +1655,7 @@ inline
 ParseResult
 Options::parse(int& argc, char**& argv)
 {
-  ParseResult result(m_options, m_positional, argc, argv);
+  ParseResult result(m_options, m_positional, m_allow_unrecognised, argc, argv);
   return result;
 }
 
@@ -1697,7 +1711,16 @@ ParseResult::parse(int& argc, char**& argv)
 
           if (iter == m_options.end())
           {
-            throw option_not_exists_exception(name);
+            if (m_allow_unrecognised)
+            {
+              ++current;
+              continue;
+            }
+            else
+            {
+              //error
+              throw option_not_exists_exception(name);
+            }
           }
 
           auto value = iter->second;
@@ -1726,7 +1749,16 @@ ParseResult::parse(int& argc, char**& argv)
 
         if (iter == m_options.end())
         {
-          throw option_not_exists_exception(name);
+          if (m_allow_unrecognised)
+          {
+            ++current;
+            continue;
+          }
+          else
+          {
+            //error
+            throw option_not_exists_exception(name);
+          }
         }
 
         auto opt = iter->second;

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1713,7 +1713,6 @@ ParseResult::parse(int& argc, char**& argv)
           {
             if (m_allow_unrecognised)
             {
-              ++current;
               continue;
             }
             else

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -37,7 +37,9 @@ int main(int argc, char* argv[])
 
     bool apple = false;
 
-    options.add_options()
+    options
+      .allow_unrecognised_options()
+      .add_options()
       ("a,apple", "an apple", cxxopts::value<bool>(apple))
       ("b,bob", "Bob")
       ("t,true", "True", cxxopts::value<bool>()->default_value("true"))

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -483,9 +483,10 @@ TEST_CASE("Unrecognised options", "[options]") {
 
   Argv av({
     "unknown_options",
+    "--unknown",
     "--long",
     "-su",
-    "--unknown",
+    "--another_unknown",
   }); 
 
   char** argv = av.argv();
@@ -498,5 +499,7 @@ TEST_CASE("Unrecognised options", "[options]") {
   SECTION("After allowing unrecognised options") {
     options.allow_unrecognised_options();
     CHECK_NOTHROW(options.parse(argc, argv));
+    REQUIRE(argc == 3);
+    CHECK_THAT(argv[1], Catch::Equals("--unknown"));
   }
 }

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -473,3 +473,30 @@ TEST_CASE("std::optional", "[optional]") {
   CHECK(*optional == "foo");
 }
 #endif
+
+TEST_CASE("Unrecognised options", "[options]") {
+  cxxopts::Options options("unknown_options", " - test unknown options");
+
+  options.add_options()
+    ("long", "a long option")
+    ("s,short", "a short option");
+
+  Argv av({
+    "unknown_options",
+    "--long",
+    "-su",
+    "--unknown",
+  }); 
+
+  char** argv = av.argv();
+  auto argc = av.argc();
+
+  SECTION("Default behaviour") {
+    CHECK_THROWS_AS(options.parse(argc, argv), cxxopts::option_not_exists_exception);
+  }
+
+  SECTION("After allowing unrecognised options") {
+    options.allow_unrecognised_options();
+    CHECK_NOTHROW(options.parse(argc, argv));
+  }
+}


### PR DESCRIPTION
For our use of cxxopts we needed support for options that are not recognized by the parser. As this was still on the project's TODO list, I implemented a proposal for that function. It can be used like this:

    options
      .allow_unrecognised_options()
      .add_options()
        ("a,apple", "an apple", cxxopts::value<bool>(apple))
        ("b,bob", "Bob")

The ``Options`` and ``ParseResult`` objects remember this setting and skip unknown arguments instead of throwing an exception if set to ``true``.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/105)
<!-- Reviewable:end -->
