### PR TITLE
Use Absolute Paths Instead of Relative Paths for CMake Configuration

### DIFF
--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cxxopts-test)
 set(CMAKE_CXX_STANDARD   11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_subdirectory(${PROJECT_SOURCE_DIR} cxxopts EXCLUDE_FROM_ALL)
+add_subdirectory(../.. cxxopts EXCLUDE_FROM_ALL)
 
 add_executable(library-test "${PROJECT_SOURCE_DIR}/src/example.cpp")
 target_link_libraries(library-test cxxopts)

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cxxopts-test)
 set(CMAKE_CXX_STANDARD   11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_subdirectory(../.. cxxopts EXCLUDE_FROM_ALL)
+add_subdirectory(${CMAKE_SOURCE_DIR} cxxopts EXCLUDE_FROM_ALL)
 
-add_executable(library-test "${PROJECT_SOURCE_DIR}/src/example.cpp")
+add_executable(library-test "${CMAKE_SOURCE_DIR}/src/example.cpp")
 target_link_libraries(library-test cxxopts)

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cxxopts-test)
 set(CMAKE_CXX_STANDARD   11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_subdirectory(../.. cxxopts EXCLUDE_FROM_ALL)
+add_subdirectory(${PROJECT_SOURCE_DIR} cxxopts EXCLUDE_FROM_ALL)
 
 add_executable(library-test "${PROJECT_SOURCE_DIR}/src/example.cpp")
 target_link_libraries(library-test cxxopts)

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -7,5 +7,5 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(../.. cxxopts EXCLUDE_FROM_ALL)
 
-add_executable(library-test "../../src/example.cpp")
+add_executable(library-test "${PROJECT_SOURCE_DIR}/src/example.cpp")
 target_link_libraries(library-test cxxopts)

--- a/test/find-package-test/CMakeLists.txt
+++ b/test/find-package-test/CMakeLists.txt
@@ -7,5 +7,5 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(cxxopts REQUIRED)
 
-add_executable(library-test "../../src/example.cpp")
+add_executable(library-test "${PROJECT_SOURCE_DIR}/src/example.cpp")
 target_link_libraries(library-test cxxopts::cxxopts)

--- a/test/find-package-test/CMakeLists.txt
+++ b/test/find-package-test/CMakeLists.txt
@@ -7,5 +7,5 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(cxxopts REQUIRED)
 
-add_executable(library-test "${PROJECT_SOURCE_DIR}/src/example.cpp")
+add_executable(library-test "${CMAKE_SOURCE_DIR}/src/example.cpp")
 target_link_libraries(library-test cxxopts::cxxopts)


### PR DESCRIPTION
This is much less likely to break code if the file is moved for some reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/112)
<!-- Reviewable:end -->
