### PR TITLE
fixed version parsing in the CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,20 +18,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 cmake_minimum_required(VERSION 3.1)
-project(cxxopts)
 
-enable_testing()
-
-file(STRINGS "${PROJECT_SOURCE_DIR}/include/cxxopts.hpp" cxxopts_version_defines
-     REGEX "#define {CXXOPTS__VERSION_(MAJOR|MINOR|PATCH)")
+# parse the current version from the cxxopts header
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/cxxopts.hpp" cxxopts_version_defines
+     REGEX "#define CXXOPTS__VERSION_(MAJOR|MINOR|PATCH)")
 foreach(ver ${cxxopts_version_defines})
-    if(ver MATCHES "#define {CXXOPTS__VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
-        set({CXXOPTS__VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
+    if(ver MATCHES "#define CXXOPTS__VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+        set(CXXOPTS__VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
     endif()
 endforeach()
 set(VERSION ${CXXOPTS__VERSION_MAJOR}.${CXXOPTS__VERSION_MINOR}.${CXXOPTS__VERSION_PATCH})
+message(STATUS "cxxopts version ${VERSION}")
 
-# set(VERSION "1.2.0")
+project(cxxopts VERSION "${VERSION}")
+
+enable_testing()
 
 option(CXXOPTS_BUILD_EXAMPLES "Set to ON to build examples" ON)
 option(CXXOPTS_BUILD_TESTS "Set to ON to build tests" OFF)


### PR DESCRIPTION
The CMake code that has been introduced in cde83be99b6308ccbaf38e2757cdb96386d0715d for parsing the version from the header seems to be broken. Note the curly brace in the regex and the set command. This commit fixes the problem for me.

On a related note, are you interested in having package manager specific files in your upstream repository? I just packaged your library with [conan](https://docs.conan.io/en/latest/) since I needed it for a project. If you want I can send a PR with the required `conanfile.py`. (see https://github.com/niosHD/cxxopts/blob/master/conanfile.py)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/128)
<!-- Reviewable:end -->
