### PR TITLE
accept single '-' as argument, such as in `cat -`

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1723,7 +1723,7 @@ ParseResult::parse(int& argc, char**& argv)
       //not a flag
 
       // but if it starts with a `-`, then it's an error
-      if (argv[current][0] == '-') {
+      if (argv[current][0] == '-' && argv[current][1] != '\0') {
         throw option_syntax_exception(argv[current]);
       }
 


### PR DESCRIPTION
Many command line utilities use the input `-` as shorthand for stdin/stdout.

This change allows accepting a single '-' as an argument, such as in `cat -`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/153)
<!-- Reviewable:end -->
