### PR TITLE
single param added extra comma for help..

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the Bug
+<!--  A clear and concise description of what the bug is. -->
+
+## How To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Console Output
+<!-- If applicable, add console input as an attachment in a txt file after you submit the issue. -->
+
+## Environment 
+<!-- Please complete the following information: -->
+- git hash:
+
+## Additional Information
+<!-- Add any other context about the problem here. -->

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1300,7 +1300,9 @@ namespace cxxopts
 
       if (s.size() > 0)
       {
-        result += "-" + toLocalString(s) + ",";
+        result += "-" + toLocalString(s);
+        if (l.size() > 0)
+            result += ",";
       }
       else
       {


### PR DESCRIPTION
If there was only a single option supplied, it printed an extra comma im help..

i.e. 
`-b,       : foo bar`

fixed so it doesnt print that extra comma for single option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/155)
<!-- Reviewable:end -->
