### PR TITLE
Remove empty string initializer.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1281,7 +1281,7 @@ namespace cxxopts
     }
 
     std::string
-    help(const std::vector<std::string>& groups = {""}) const;
+    help(const std::vector<std::string>& groups = {}) const;
 
     const std::vector<std::string>
     groups() const;


### PR DESCRIPTION
The empty string caused the vector to have one element which caused
the test at line 2041 to always fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/159)
<!-- Reviewable:end -->
