### PR TITLE
Break words if longer than allowed length

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1456,6 +1456,7 @@ namespace cxxopts
             stringAppend(result, "\n");
             stringAppend(result, start, ' ');
             startLine = lastSpace + 1;
+            lastSpace = startLine;
           }
           size = 0;
         }


### PR DESCRIPTION
If a word is longer than the allowed length in an option's description, the program crashes when formatting it with the following exception (c.f. issue #95):
```
libc++abi.dylib: terminating with uncaught exception of type std::length_error: basic_string
Abort trap: 6
```

The algorithm insert words until the maximum allowed length is reached; then we insert a new line `\n` character and start again from the previous space character (i.e. the word that could not fit on the previous line). We therefore keep a pointer to the first character of the current line and the previous space.

If a word is longer than the allowed length, it will break the previous line, but cannot fit on the next one. The algorithm will try to insert the first part (with exactly the maximum allowed length), but the previous space is still on the previous line.

Setting the last space character to the first character of the new line prevents that bug.

Solve #95.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/167)
<!-- Reviewable:end -->
