### PR TITLE
Throw option_required_exception if option value is not present

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1044,6 +1044,12 @@ namespace cxxopts
       return m_count;
     }
 
+    bool
+    has_value() const
+    {
+      return m_value != nullptr;
+    }
+
     template <typename T>
     const T&
     as() const
@@ -1147,6 +1153,10 @@ namespace cxxopts
       }
 
       auto riter = m_results.find(iter->second);
+      if (!riter->second.has_value())
+      {
+        throw option_required_exception(option);
+      }
 
       return riter->second;
     }

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Basic options", "[options]")
   CHECK(arguments[2].key() == "value");
   CHECK(arguments[3].key() == "av");
   
-  CHECK_THROWS_AS(result["nothing"].as<std::string>(), std::domain_error&);
+  CHECK_THROWS_AS(result["nothing"], cxxopts::option_required_exception&);
 }
 
 TEST_CASE("Short options", "[options]")


### PR DESCRIPTION
Currently an std::domain_error is thrown in as(), but this does not show the missing option name. Proposed PR throws in ParseResult.operator[] when trying to get an option without a value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/168)
<!-- Reviewable:end -->
