### PR TITLE
Remove check for container when generating help message.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1938,8 +1938,7 @@ Options::help_one_group(const std::string& g) const
 
   for (const auto& o : group->second.options)
   {
-    if (o.is_container &&
-        m_positional_set.find(o.l) != m_positional_set.end() &&
+    if (m_positional_set.find(o.l) != m_positional_set.end() &&
         !m_show_positional)
     {
       continue;
@@ -1958,8 +1957,7 @@ Options::help_one_group(const std::string& g) const
   auto fiter = format.begin();
   for (const auto& o : group->second.options)
   {
-    if (o.is_container &&
-        m_positional_set.find(o.l) != m_positional_set.end() &&
+    if (m_positional_set.find(o.l) != m_positional_set.end() &&
         !m_show_positional)
     {
       continue;


### PR DESCRIPTION
Some positional parameters would be listed in the help text and others
would not, when what is desired is that no positional parameters are
listed with the other command options. This change suppresses the help
listing for all positional parameters.

For the following example,

```  
  m_cmd_options->add_options()
    ( "h,help", "Display usage" );

  m_cmd_options->add_options("pipe")
    ( "c,config", "File name containing supplemental configuration entries. Can occur multiple times.",
      cxxopts::value<std::vector<std::string>>() );

    // positional parameters
  m_cmd_options->add_options()
    ( "p,pipe-file", "Input file", cxxopts::value<std::string>())
    ( "extra", "Extra command line args",  cxxopts::value<std::vector<std::string>>());

  m_cmd_options->parse_positional({"pipe-file", "extra"});
```
The group help for pipe-file would be displayed and the help for "extra" would not. This is because the "extra" command option referred to a container. I propose to remove the test for a container from the code that generates the help text. This will skip all positional parameters without regard for being a container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/170)
<!-- Reviewable:end -->
