### PR TITLE
Fix warnings with -Wsign-conversion.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -568,15 +568,15 @@ namespace cxxopts
 
         if (*iter >= '0' && *iter <= '9')
         {
-          digit = *iter - '0';
+          digit = static_cast<US>(*iter - '0');
         }
         else if (base == 16 && *iter >= 'a' && *iter <= 'f')
         {
-          digit = *iter - 'a' + 10;
+          digit = static_cast<US>(*iter - 'a' + 10);
         }
         else if (base == 16 && *iter >= 'A' && *iter <= 'F')
         {
-          digit = *iter - 'A' + 10;
+          digit = static_cast<US>(*iter - 'A' + 10);
         }
         else
         {
@@ -601,7 +601,7 @@ namespace cxxopts
       }
       else
       {
-        value = result;
+        value = static_cast<T>(result);
       }
     }
 


### PR DESCRIPTION
I had a number of warnings about implicit conversion between differently signed types. I'm running on GCC 8.3.0 with `-Wsign-conversion` enabled.

I simply added a number of static casts to be more explicit. If anything looks wrong here, please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/174)
<!-- Reviewable:end -->
