### PR TITLE
Parse 0 and 1 into booleans

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -466,9 +466,9 @@ namespace cxxopts
       std::basic_regex<char> integer_pattern
         ("(-)?(0x)?([0-9a-zA-Z]+)|((0x)?0)");
       std::basic_regex<char> truthy_pattern
-        ("(t|T)(rue)?");
+        ("(t|T)(rue)?|1");
       std::basic_regex<char> falsy_pattern
-        ("((f|F)(alse)?)?");
+        ("(f|F)(alse)?|0");
     }
 
     namespace detail

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -468,6 +468,8 @@ TEST_CASE("Booleans", "[boolean]") {
     ("bool", "A Boolean", cxxopts::value<bool>())
     ("debug", "Debugging", cxxopts::value<bool>())
     ("timing", "Timing", cxxopts::value<bool>())
+    ("verbose", "Verbose", cxxopts::value<bool>())
+    ("dry-run", "Dry Run", cxxopts::value<bool>())
     ("noExplicitDefault", "No Explicit Default", cxxopts::value<bool>())
     ("defaultTrue", "Timing", cxxopts::value<bool>()->default_value("true"))
     ("defaultFalse", "Timing", cxxopts::value<bool>()->default_value("false"))
@@ -476,7 +478,7 @@ TEST_CASE("Booleans", "[boolean]") {
 
   options.parse_positional("others");
 
-  Argv av({"booleans", "--bool=false", "--debug=true", "--timing", "extra"});
+  Argv av({"booleans", "--bool=false", "--debug=true", "--timing", "--verbose=1", "--dry-run=0", "extra"});
 
   char** argv = av.argv();
   auto argc = av.argc();
@@ -486,6 +488,8 @@ TEST_CASE("Booleans", "[boolean]") {
   REQUIRE(result.count("bool") == 1);
   REQUIRE(result.count("debug") == 1);
   REQUIRE(result.count("timing") == 1);
+  REQUIRE(result.count("verbose") == 1);
+  REQUIRE(result.count("dry-run") == 1);
   REQUIRE(result.count("noExplicitDefault") == 0);
   REQUIRE(result.count("defaultTrue") == 0);
   REQUIRE(result.count("defaultFalse") == 0);
@@ -493,6 +497,8 @@ TEST_CASE("Booleans", "[boolean]") {
   CHECK(result["bool"].as<bool>() == false);
   CHECK(result["debug"].as<bool>() == true);
   CHECK(result["timing"].as<bool>() == true);
+  CHECK(result["verbose"].as<bool>() == true);
+  CHECK(result["dry-run"].as<bool>() == false);
   CHECK(result["noExplicitDefault"].as<bool>() == false);
   CHECK(result["defaultTrue"].as<bool>() == true);
   CHECK(result["defaultFalse"].as<bool>() == false);


### PR DESCRIPTION
Regular expressions to parse boolean options currently do not accept "0" nor "1". In my opinion, these values should respectively be parsed as "false" and "true", so that such commands `./myprogram --option=0` are valid.

Similarly, empty values are accepted and parsed as "false", which is error-prone. No error is raised when an argument is missing, eg. with `./myprogram --option` or `./myprogram --option=`. This is equivalent to setting "false" as the implicit default value, so that the behaviour can be recovered if necessary. I propose to remove this behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/177)
<!-- Reviewable:end -->
