### PR TITLE
Add a method to remove the implicit value of an option

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -309,6 +309,9 @@ namespace cxxopts
     virtual std::shared_ptr<Value>
     implicit_value(const std::string& value) = 0;
 
+    virtual std::shared_ptr<Value>
+    no_implicit_value() = 0;
+
     virtual bool
     is_boolean() const = 0;
   };
@@ -822,6 +825,13 @@ namespace cxxopts
       {
         m_implicit = true;
         m_implicit_value = value;
+        return shared_from_this();
+      }
+
+      std::shared_ptr<Value>
+      no_implicit_value()
+      {
+        m_implicit = false;
         return shared_from_this();
       }
 

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -250,6 +250,67 @@ TEST_CASE("Empty with implicit value", "[implicit]")
   REQUIRE(result["implicit"].as<std::string>() == "");
 }
 
+TEST_CASE("Boolean without implicit value", "[implicit]")
+{
+  cxxopts::Options options("no_implicit", "bool without an implicit value");
+  options.add_options()
+    ("bool", "Boolean without implicit", cxxopts::value<bool>()
+      ->no_implicit_value());
+
+  SECTION("When no value provided") {
+    Argv av({"no_implicit", "--bool"});
+
+    char** argv = av.argv();
+    auto argc = av.argc();
+
+    CHECK_THROWS_AS(options.parse(argc, argv), cxxopts::missing_argument_exception&);
+  }
+
+  SECTION("With equal-separated true") {
+    Argv av({"no_implicit", "--bool=true"});
+
+    char** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+    CHECK(result.count("bool") == 1);
+    CHECK(result["bool"].as<bool>() == true);
+  }
+
+  SECTION("With equal-separated false") {
+    Argv av({"no_implicit", "--bool=false"});
+
+    char** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+    CHECK(result.count("bool") == 1);
+    CHECK(result["bool"].as<bool>() == false);
+  }
+
+  SECTION("With space-separated true") {
+    Argv av({"no_implicit", "--bool", "true"});
+
+    char** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+    CHECK(result.count("bool") == 1);
+    CHECK(result["bool"].as<bool>() == true);
+  }
+
+  SECTION("With space-separated false") {
+    Argv av({"no_implicit", "--bool", "false"});
+
+    char** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+    CHECK(result.count("bool") == 1);
+    CHECK(result["bool"].as<bool>() == false);
+  }
+}
+
 TEST_CASE("Default values", "[default]")
 {
   cxxopts::Options options("defaults", "has defaults");


### PR DESCRIPTION
An option with an implicit value can be used without setting a value, such as `my_program --myoption`. However, if the user wishes to set a custom value, only the syntax with an equal sign will be recognized (`--myoption=myvalue`). The usual syntax using a space character to separate the option and the value (`--myoption myvalue`) is invalid, since it is not possible to disambiguate it from a positional argument.

This is not a problem in general, because the user has the choice to set an implicit value, or leave the option without an implicit value. In this last case, the syntax `my_program --myoption` is not valid, and `my_program --myoption myvalue` is correct.

In the case of boolean options, `true` is automatically set as the implicit value and there's currently no way to prevent that. This might be an issue if one wants to support the syntax `--myoption myvalue`.

I propose to add a method `no_implicit_value()`, so that the user can disable the automatic implicit value, which is set for boolean options. This is how it might be used:

```cpp
cxxopts::Options parser = cxxopts::Options("my_program");
parser.add_options()
    ("h,help", "show this help message and exit")
    ("with-implicit", "boolean with auto implicit value", cxxopts::value<bool>())
    ("no-implicit", "boolean without implicit value", cxxopts::value<bool>()->no_implicit_value());
```

so that we the following command throws an error:
```shell
my_program --no-implicit
```

but the following command is valid, and `with-implicit` is parse to `true`, `no-implicit` parsed to `false`:
```shell
my_program --with-implicit --no-implicit false
```

Unit tests are added to check this behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/178)
<!-- Reviewable:end -->
