### PR TITLE
Create a exception to thow when Options not exists

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -394,6 +394,15 @@ namespace cxxopts
     }
   };
 
+  class option_value_not_exists_exception : public OptionParseException
+  {
+    public:
+    option_value_not_exists_exception()
+    : OptionParseException("Option value does not exist")
+    {
+    }
+  };
+
   class missing_argument_exception : public OptionParseException
   {
     public:
@@ -1068,7 +1077,7 @@ namespace cxxopts
     as() const
     {
       if (m_value == nullptr) {
-        throw std::domain_error("No value");
+        throw option_value_not_exists_exception();
       }
 
 #ifdef CXXOPTS_NO_RTTI


### PR DESCRIPTION
When the user try to get a option that not exist, cxxopt library
throw a std::domain_error, that make a segfaults. See #185.

On this PR I create a new Exception class from OptionParseException
that is throw when this situation occur. This avoid the SegFaults
error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/186)
<!-- Reviewable:end -->
