### PR TITLE
add_options variant with initializer list

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1220,6 +1220,14 @@ namespace cxxopts
 
     std::vector<KeyValue> m_sequential;
   };
+  
+  struct Option 
+  {
+    std::string opts;
+    std::string desc;
+    std::shared_ptr<const Value> value = ::cxxopts::value<bool>();
+    std::string arg_help = "";
+  };  
 
   class Options
   {
@@ -1272,6 +1280,13 @@ namespace cxxopts
 
     OptionAdder
     add_options(std::string group = "");
+	
+	void
+    add_options
+	(
+	  const std::string& group,
+	  std::initializer_list<Option> options
+	);
 
     void
     add_option
@@ -1509,6 +1524,21 @@ ParseResult::ParseResult
 , m_allow_unrecognised(allow_unrecognised)
 {
   parse(argc, argv);
+}
+
+inline
+void 
+Options::add_options
+(
+  const std::string &group,
+  std::initializer_list<Option> options
+) 
+{
+ OptionAdder option_adder(*this, group);
+ for (const auto &option: options) 
+ {
+   option_adder(option.opts, option.desc, option.value, option.arg_help);
+ }
 }
 
 inline

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1223,10 +1223,24 @@ namespace cxxopts
   
   struct Option 
   {
-    std::string opts;
-    std::string desc;
-    std::shared_ptr<const Value> value = ::cxxopts::value<bool>();
-    std::string arg_help = "";
+    Option
+    (
+      const std::string& opts,
+      const std::string& desc,
+      const std::shared_ptr<const Value>& value = ::cxxopts::value<bool>(),
+      const std::string& arg_help = ""
+    )
+    : opts_(opts)
+    , desc_(desc)
+    , value_(value)
+    , arg_help_(arg_help)
+    {
+    }
+
+    std::string opts_;
+    std::string desc_;
+    std::shared_ptr<const Value> value_;
+    std::string arg_help_;
   };  
 
   class Options
@@ -1544,7 +1558,7 @@ Options::add_options
  OptionAdder option_adder(*this, group);
  for (const auto &option: options) 
  {
-   option_adder(option.opts, option.desc, option.value, option.arg_help);
+   option_adder(option.opts_, option.desc_, option.value_, option.arg_help_);
  }
 }
 

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1288,6 +1288,13 @@ namespace cxxopts
 	  std::initializer_list<Option> options
 	);
 
+	void
+	add_option
+	(
+	  const std::string& group,
+	  const Option& option
+	);
+
     void
     add_option
     (
@@ -1913,6 +1920,17 @@ ParseResult::parse(int& argc, char**& argv)
 
   argc = nextKeep;
 
+}
+
+inline
+void
+Options::add_option
+(
+  const std::string& group,
+  const Option& option
+)
+{
+	add_options(group, {option});
 }
 
 inline


### PR DESCRIPTION
This adds variant of Options::add_options with initializer list rather than (in my opinion) strange looking(taking into account syntax features of modern c++) solution with OptionAdder and opeator()

To take advantage of Option struct I also added add_option(string, Option); variant.

Example:

```
options.add_options("", { 
{"a, address", "server address", cxxopts::value<std::string>()->default_value("127.0.0.1")},
{"p, port", "server port", cxxopts::value<std::string>()->default_value("7110")}
});


options.add_option("", {"h, help",    "help"});

cxxopts::Option option_d{"d,data", "Data"};
options.add_option("", option_d);
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/189)
<!-- Reviewable:end -->
