### PR TITLE
CMake: search only for C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endforeach()
 set(VERSION ${CXXOPTS__VERSION_MAJOR}.${CXXOPTS__VERSION_MINOR}.${CXXOPTS__VERSION_PATCH})
 message(STATUS "cxxopts version ${VERSION}")
 
-project(cxxopts VERSION "${VERSION}")
+project(cxxopts VERSION "${VERSION}" LANGUAGES CXX)
 
 enable_testing()
 


### PR DESCRIPTION
This speeds up the CMake configuration step by not searching for a C
compiler. By default, CMake looks for C and C++ compilers, unless a set
of compilation languages is specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/192)
<!-- Reviewable:end -->
