### PR TITLE
Define alias target cxxopts::cxxopts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES
 endif()
 
 add_library(cxxopts INTERFACE)
+add_library(cxxopts::cxxopts ALIAS cxxopts)
 
 # optionally, enable unicode support using the ICU library
 set(CXXOPTS_USE_UNICODE_HELP FALSE CACHE BOOL "Use ICU Unicode library")


### PR DESCRIPTION
When locating cxxopts with find_package(), the target cxxopts::cxxopts will be available to link against. If instead bundling cxxopts within another project and adding it using add_subdirectory(), the target is called cxxopts.

This small patch adds an alias to make the target name consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/194)
<!-- Reviewable:end -->
