### PR TITLE
Get default value of boolean from get()

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -949,7 +949,7 @@ namespace cxxopts
       set_default_and_implicit()
       {
         m_default = true;
-        m_default_value = "false";
+        m_default_value = get() ? "true" : "false";
         m_implicit = true;
         m_implicit_value = "true";
       }


### PR DESCRIPTION
It's more handy for boolean parameters with default values.
```c++
struct Options {
  bool foo = true;
  double bar = 1;
};
Options options = {};
cxxopts::Options parser("foobar");
parser.add_options()
  ("f,foo", "foo", cxxopts::value<bool>(options.foo))
  ("b,bar", "bar", cxxopts::value<double>(options.bar))
  ;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/200)
<!-- Reviewable:end -->
