### PR TITLE
allow empty string to be valid positional arguments

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -743,6 +743,12 @@ namespace cxxopts
     void
     parse_value(const std::string& text, std::vector<T>& value)
     {
+      if (text.empty()) {
+	T v;
+	parse_value(text, v);
+	value.emplace_back(std::move(v));
+	return;
+      }
       std::stringstream in(text);
       std::string token;
       while(in.eof() == false && std::getline(in, token, CXXOPTS_VECTOR_DELIMITER)) {


### PR DESCRIPTION
*cxxopts* doesn’t accept empty string from positional argument, but silently disregard it instead, this should’ve been the ideal solution, i.e. when running `ssh-keygen -t rsa -N “”`. Passing `\”\”` wouldn’t help either. This PR tries to allow passing empty string for positional arguments.