### PR TITLE
sun hack

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -39,6 +39,10 @@ THE SOFTWARE.
 #include <unordered_set>
 #include <vector>
 
+#ifdef __sun
+#define int8_t signed char
+#endif
+
 #ifdef __cpp_lib_optional
 #include <optional>
 #define CXXOPTS_HAS_OPTIONAL


### PR DESCRIPTION
plain char is signed on Oracle's IX86-based hardware (and legacy x86 Sun workstations) just like every other OS that runs on the Intel Pentium Pro, but compilers on this platform _**do not**_ treat plain `char` as a type distinct from `signed` /`unsigned char` such that `int8_t` and `char` resolve to the same type, triggering an error in compilation

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/221)
<!-- Reviewable:end -->
