### PR TITLE
Fix compiler warning C4702 for MSVC-14

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -556,7 +556,7 @@ namespace cxxopts
 
     template <typename R, typename T>
     void
-      checked_negate(R&, T&&, const std::string& text, std::false_type)
+    checked_negate(R&, T&&, const std::string& text, std::false_type)
     {
       throw_or_mimic<argument_incorrect_type>(text);
     }

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -544,22 +544,22 @@ namespace cxxopts
       }
     }
 
-	template <typename R, typename T>
-	void
-	checked_negate(R& r, T&& t, const std::string&, std::true_type)
-	{
-		// if we got to here, then `t` is a positive number that fits into
-		// `R`. So to avoid MSVC C4146, we first cast it to `R`.
-		// See https://github.com/jarro2783/cxxopts/issues/62 for more details.
-		r = static_cast<R>(-static_cast<R>(t-1)-1);
-	}
+    template <typename R, typename T>
+    void
+    checked_negate(R& r, T&& t, const std::string&, std::true_type)
+    {
+      // if we got to here, then `t` is a positive number that fits into
+      // `R`. So to avoid MSVC C4146, we first cast it to `R`.
+      // See https://github.com/jarro2783/cxxopts/issues/62 for more details.
+      r = static_cast<R>(-static_cast<R>(t-1)-1);
+    }
 
-	template <typename R, typename T>
-	void
-	checked_negate(R&, T&&, const std::string& text, std::false_type)
-	{
-		throw_or_mimic<argument_incorrect_type>(text);
-	}
+    template <typename R, typename T>
+    void
+      checked_negate(R&, T&&, const std::string& text, std::false_type)
+    {
+      throw_or_mimic<argument_incorrect_type>(text);
+    }
 
     template <typename T>
     void
@@ -623,7 +623,7 @@ namespace cxxopts
 
       if (negative)
       {
-	    checked_negate<T>(value, result, text, std::integral_constant<bool, is_signed>());
+        checked_negate<T>(value, result, text, std::integral_constant<bool, is_signed>());
       }
       else
       {

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -544,23 +544,22 @@ namespace cxxopts
       }
     }
 
-    template <typename R, typename T>
-    R
-    checked_negate(T&& t, const std::string&, std::true_type)
-    {
-      // if we got to here, then `t` is a positive number that fits into
-      // `R`. So to avoid MSVC C4146, we first cast it to `R`.
-      // See https://github.com/jarro2783/cxxopts/issues/62 for more details.
-      return static_cast<R>(-static_cast<R>(t-1)-1);
-    }
+	template <typename R, typename T>
+	void
+	checked_negate(R& r, T&& t, const std::string&, std::true_type)
+	{
+		// if we got to here, then `t` is a positive number that fits into
+		// `R`. So to avoid MSVC C4146, we first cast it to `R`.
+		// See https://github.com/jarro2783/cxxopts/issues/62 for more details.
+		r = static_cast<R>(-static_cast<R>(t-1)-1);
+	}
 
-    template <typename R, typename T>
-    T
-    checked_negate(T&& t, const std::string& text, std::false_type)
-    {
-      throw_or_mimic<argument_incorrect_type>(text);
-      return t;
-    }
+	template <typename R, typename T>
+	void
+	checked_negate(R&, T&&, const std::string& text, std::false_type)
+	{
+		throw_or_mimic<argument_incorrect_type>(text);
+	}
 
     template <typename T>
     void
@@ -624,9 +623,7 @@ namespace cxxopts
 
       if (negative)
       {
-        value = checked_negate<T>(result,
-          text,
-          std::integral_constant<bool, is_signed>());
+	    checked_negate<T>(value, result, text, std::integral_constant<bool, is_signed>());
       }
       else
       {


### PR DESCRIPTION
## Justification
MSVC-14 shows a warning C4702 when the code is compiled.
Details on the warning: `cxxopts.hpp(562) : warning C4702: unreachable code`.
The unreachable line is `return t;` in line 562.
## Implementation
To get rid of the unreachable code, now `checked_negate` receives by reference the `value` and updates it instead of returning.
## Testing:
- Code compiles and warning C4702 is gone.
- All tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/225)
<!-- Reviewable:end -->
