### PR TITLE
Fix compile issue due to utf-8 symbols

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 Copyright (c) 2014, 2015, 2016, 2017 Jarryd Beck
 


### PR DESCRIPTION
Visual Studio throws warnings because of LQUOTE and RQUOTE values:

    The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss

Perhaps most proper solution is to add BOM mark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/232)
<!-- Reviewable:end -->
