### PR TITLE
On error, one should exit and not abort. 

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -480,11 +480,10 @@ namespace cxxopts
     throw T{text};
 #else
     // Otherwise manually instantiate the exception, print what() to stderr,
-    // and abort
+    // and exit
     T exception{text};
     std::cerr << exception.what() << std::endl;
-    std::cerr << "Aborting (exceptions disabled)..." << std::endl;
-    std::abort();
+    std::exit(EXIT_FAILURE);
 #endif
   }
 


### PR DESCRIPTION
Aborting bypasses destructors and dumps core. It is harsh and potentially dangerous. We want a nice error message, even when exceptions and disabled, not a "dumping core" message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/233)
<!-- Reviewable:end -->
