### PR TITLE
Making sure that the library can compile without warnings even when crazy pedantic flags are set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W2")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wshadow")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wshadow -Weffc++ -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion")
 endif()
 
 add_library(cxxopts INTERFACE)

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1050,8 +1050,7 @@ namespace cxxopts
     std::string m_short{};
     std::string m_long{};
     String m_desc{};
-    std::shared_ptr<const Value> m_value{}
-    ;
+    std::shared_ptr<const Value> m_value{};
     int m_count;
   };
 
@@ -1481,6 +1480,10 @@ namespace cxxopts
       if (!s.empty())
       {
         result += "-" + toLocalString(s) + ",";
+        if (!l.empty())		
+        {		
+          result += ",";		
+        }
       }
       else
       {

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1479,10 +1479,10 @@ namespace cxxopts
 
       if (!s.empty())
       {
-        result += "-" + toLocalString(s) + ",";
-        if (!l.empty())		
-        {		
-          result += ",";		
+        result += "-" + toLocalString(s);
+        if (!l.empty())
+        {
+          result += ",";
         }
       }
       else

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1084,7 +1084,7 @@ namespace cxxopts
     std::shared_ptr<const Value> m_value{};
     int m_count;
 
-    size_t m_hash;
+    size_t m_hash{};
   };
 
   struct HelpOptionDetails
@@ -1373,11 +1373,11 @@ namespace cxxopts
     const OptionMap& m_options;
     const PositionalList& m_positional;
 
-    std::vector<KeyValue> m_sequential;
+    std::vector<KeyValue> m_sequential{};
     bool m_allow_unrecognised;
 
-    ParsedHashMap m_parsed;
-    NameHashMap m_keys;
+    ParsedHashMap m_parsed{};
+    NameHashMap m_keys{};
   };
 
   class Options

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -147,9 +147,9 @@ namespace cxxopts
 
   inline
   String&
-  stringAppend(String& s, int n, UChar32 c)
+  stringAppend(String& s, size_t n, UChar32 c)
   {
-    for (int i = 0; i != n; ++i)
+    for (size_t i = 0; i != n; ++i)
     {
       s.append(c);
     }

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -278,6 +278,13 @@ namespace cxxopts
 #endif
   } // namespace
 
+#if defined(__GNUC__)
+// GNU GCC with -Weffc++ will issue a warning regarding the upcoming class, we want to silence it:
+// warning: base class 'class std::enable_shared_from_this<cxxopts::Value>' has accessible non-virtual destructor
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#pragma GCC diagnostic push
+// This will be ignored under other compilers like LLVM clang.
+#endif
   class Value : public std::enable_shared_from_this<Value>
   {
     public:
@@ -321,7 +328,9 @@ namespace cxxopts
     virtual bool
     is_boolean() const = 0;
   };
-
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   class OptionException : public std::exception
   {
     public:
@@ -805,6 +814,8 @@ namespace cxxopts
 
       ~abstract_value() override = default;
 
+      abstract_value& operator=(const abstract_value&) = default;
+
       abstract_value(const abstract_value& rhs)
       {
         if (rhs.m_result)
@@ -905,14 +916,14 @@ namespace cxxopts
       }
 
       protected:
-      std::shared_ptr<T> m_result;
-      T* m_store;
+      std::shared_ptr<T> m_result{};
+      T* m_store{};
 
       bool m_default = false;
       bool m_implicit = false;
 
-      std::string m_default_value;
-      std::string m_implicit_value;
+      std::string m_default_value{};
+      std::string m_implicit_value{};
     };
 
     template <typename T>
@@ -1036,10 +1047,11 @@ namespace cxxopts
     }
 
     private:
-    std::string m_short;
-    std::string m_long;
-    String m_desc;
-    std::shared_ptr<const Value> m_value;
+    std::string m_short{};
+    std::string m_long{};
+    String m_desc{};
+    std::shared_ptr<const Value> m_value{}
+    ;
     int m_count;
   };
 
@@ -1059,9 +1071,9 @@ namespace cxxopts
 
   struct HelpGroupDetails
   {
-    std::string name;
-    std::string description;
-    std::vector<HelpOptionDetails> options;
+    std::string name{};
+    std::string description{};
+    std::vector<HelpOptionDetails> options{};
   };
 
   class OptionValue
@@ -1125,7 +1137,7 @@ namespace cxxopts
       }
     }
 
-    std::shared_ptr<Value> m_value;
+    std::shared_ptr<Value> m_value{};
     size_t m_count = 0;
     bool m_default = false;
   };
@@ -1249,14 +1261,14 @@ namespace cxxopts
     const std::shared_ptr<
       std::unordered_map<std::string, std::shared_ptr<OptionDetails>>
     > m_options;
-    std::vector<std::string> m_positional;
+    std::vector<std::string> m_positional{};
     std::vector<std::string>::iterator m_next_positional;
-    std::unordered_set<std::string> m_positional_set;
-    std::unordered_map<std::shared_ptr<OptionDetails>, OptionValue> m_results;
+    std::unordered_set<std::string> m_positional_set{};
+    std::unordered_map<std::shared_ptr<OptionDetails>, OptionValue> m_results{};
 
     bool m_allow_unrecognised;
 
-    std::vector<KeyValue> m_sequential;
+    std::vector<KeyValue> m_sequential{};
   };
 
   struct Option
@@ -1406,18 +1418,18 @@ namespace cxxopts
 
     std::string m_program;
     String m_help_string;
-    std::string m_custom_help;
+    std::string m_custom_help{};
     std::string m_positional_help;
     bool m_show_positional;
     bool m_allow_unrecognised;
 
     std::shared_ptr<OptionMap> m_options;
-    std::vector<std::string> m_positional;
+    std::vector<std::string> m_positional{};
     std::vector<std::string>::iterator m_next_positional;
-    std::unordered_set<std::string> m_positional_set;
+    std::unordered_set<std::string> m_positional_set{};
 
     //mapping from groups to help options
-    std::map<std::string, HelpGroupDetails> m_help;
+    std::map<std::string, HelpGroupDetails> m_help{};
   };
 
   class OptionAdder
@@ -1468,11 +1480,7 @@ namespace cxxopts
 
       if (!s.empty())
       {
-        result += "-" + toLocalString(s);
-        if (!l.empty())
-        {
-          result += ",";
-        }
+        result += "-" + toLocalString(s) + ",";
       }
       else
       {

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -36,7 +36,7 @@ class Argv {
 
   private:
 
-  std::vector<std::unique_ptr<char[]>> m_args;
+  std::vector<std::unique_ptr<char[]>> m_args{};
   std::unique_ptr<const char*[]> m_argv;
   int m_argc;
 };


### PR DESCRIPTION
We use cxxopts in simdjson since some of our users get upset if they get warnings (sometimes calling these warnings 'bugs').

We can disable the warnings on our end, but it might be nicer for everyone if cxxopts was also "warning free". This PR should help.

It does two things:

- It adds the "{}" suffix to class-type attributes that are not explicitly initialized by all constructors. This effectively makes sure that they are initialized with a default constructor.
- It disables some specific GCC warning for the duration of the definition/declaration of a class.

None of these changes should impact the performance or the functionality of the library.

Note that it is not my claim that I am fixing defects. This is purely to save time in the long term by not getting warnings. 

cc @jkeiser

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/238)
<!-- Reviewable:end -->
