### PR TITLE
Fixes #245: Mention the option name when throwing on "no value"

### DIFF
--- a/test/options.cpp
+++ b/test/options.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Basic options", "[options]")
   CHECK(arguments[2].key() == "value");
   CHECK(arguments[3].key() == "av");
 
-  CHECK_THROWS_AS(result["nothing"].as<std::string>(), std::domain_error&);
+  CHECK_THROWS_AS(result["nothing"].as<std::string>(), cxxopts::option_has_no_value_exception&);
 }
 
 TEST_CASE("Short options", "[options]")


### PR DESCRIPTION
* Added a new exception type: `option_has_no_value_exception`; throwing it when an option has no value we can cast with `as()`, instead of an `std::domain_error`.
* The `OptionValue` type now holds a pointer to the long option name (in its corresponding key within ParseResults's `m_results` field.
* Adjusted tests accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/246)
<!-- Reviewable:end -->
