### PR TITLE
Fix constness of Options::parse

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1414,6 +1414,9 @@ namespace cxxopts
     ParseResult
     parse(int argc, const char** argv);
 
+    ParseResult
+    parse(int argc, char** argv);
+
     OptionAdder
     add_options(std::string group = "");
 
@@ -1870,6 +1873,15 @@ Options::parse(int argc, const char** argv)
   OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
 
   return parser.parse(argc, argv);
+}
+
+inline
+ParseResult
+Options::parse(int argc, char** argv)
+{
+  OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
+
+  return parser.parse(argc, const_cast<const char**>(argv));
 }
 
 inline ParseResult


### PR DESCRIPTION
Same way as in 2.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/257)
<!-- Reviewable:end -->
