### PR TITLE
Fix passing a const array to parse

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1325,7 +1325,7 @@ namespace cxxopts
     }
 
     ParseResult
-    parse(int argc, const char** argv);
+    parse(int argc, const char* const* argv);
 
     bool
     consume_positional(const std::string& a, PositionalListIterator& next);
@@ -1334,7 +1334,7 @@ namespace cxxopts
     checked_parse_arg
     (
       int argc,
-      const char* argv[],
+      const char* const* argv,
       int& current,
       const std::shared_ptr<OptionDetails>& value,
       const std::string& name
@@ -1412,7 +1412,7 @@ namespace cxxopts
     }
 
     ParseResult
-    parse(int argc, const char** argv);
+    parse(int argc, const char* const* argv);
 
     OptionAdder
     add_options(std::string group = "");
@@ -1772,7 +1772,7 @@ void
 OptionParser::checked_parse_arg
 (
   int argc,
-  const char* argv[],
+  const char* const* argv,
   int& current,
   const std::shared_ptr<OptionDetails>& value,
   const std::string& name
@@ -1865,7 +1865,7 @@ Options::parse_positional(std::initializer_list<std::string> options)
 
 inline
 ParseResult
-Options::parse(int argc, const char** argv)
+Options::parse(int argc, const char* const* argv)
 {
   OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
 
@@ -1873,7 +1873,7 @@ Options::parse(int argc, const char** argv)
 }
 
 inline ParseResult
-OptionParser::parse(int argc, const char** argv)
+OptionParser::parse(int argc, const char* const* argv)
 {
   int current = 1;
   bool consume_remaining = false;

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -773,3 +773,9 @@ TEST_CASE("Option add with add_option(string, Option)", "[options]") {
   CHECK(result["aggregate"].as<int>() == 4);
   CHECK(result["test"].as<int>() == 5);
 }
+
+TEST_CASE("Const array", "[const]") {
+  const char* const option_list[] = {"empty", "options"};
+  cxxopts::Options options("Empty options", " - test constness");
+  auto result = options.parse(2, option_list);
+}


### PR DESCRIPTION
Fixes #257. The input array is not modified, so we can declare this as
`char const* const*`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/258)
<!-- Reviewable:end -->
