### PR TITLE
add CMake option to not add warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ enable_testing()
 option(CXXOPTS_BUILD_EXAMPLES "Set to ON to build examples" ON)
 option(CXXOPTS_BUILD_TESTS "Set to ON to build tests" ON)
 option(CXXOPTS_ENABLE_INSTALL "Generate the install target" ON)
+option(CXXOPTS_ENABLE_WARNINGS "Add warnings to CMAKE_CXX_FLAGS" ON)
 
 # request c++11 without gnu extension for the whole project and enable more warnings
 if (CXXOPTS_CXX_STANDARD)
@@ -47,10 +48,12 @@ endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if (CXXOPTS_ENABLE_WARNINGS)
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W2")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wshadow -Weffc++ -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion -Wsuggest-override")
+endif()
 endif()
 
 add_library(cxxopts INTERFACE)


### PR DESCRIPTION
this is useful to use with compilers that
don't support those warning flags,
such as my recent Apple Clang compiler

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/267)
<!-- Reviewable:end -->
