### PR TITLE
Cmake Revamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 # Copyright (c) 2014 Jarryd Beck
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -17,96 +17,61 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.19)
 
-# parse the current version from the cxxopts header
-file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/cxxopts.hpp" cxxopts_version_defines
-     REGEX "#define CXXOPTS__VERSION_(MAJOR|MINOR|PATCH)")
-foreach(ver ${cxxopts_version_defines})
-    if(ver MATCHES "#define CXXOPTS__VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
-        set(CXXOPTS__VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
-    endif()
-endforeach()
-set(VERSION ${CXXOPTS__VERSION_MAJOR}.${CXXOPTS__VERSION_MINOR}.${CXXOPTS__VERSION_PATCH})
-message(STATUS "cxxopts version ${VERSION}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+include(cxxopts)
 
-project(cxxopts VERSION "${VERSION}" LANGUAGES CXX)
+# Get the version of the library
+cxxopts_getversion(VERSION)
 
-enable_testing()
+project(cxxopts
+    VERSION "${VERSION}"
+    LANGUAGES CXX
+)
 
-option(CXXOPTS_BUILD_EXAMPLES "Set to ON to build examples" ON)
-option(CXXOPTS_BUILD_TESTS "Set to ON to build tests" ON)
-option(CXXOPTS_ENABLE_INSTALL "Generate the install target" ON)
-option(CXXOPTS_ENABLE_WARNINGS "Add warnings to CMAKE_CXX_FLAGS" ON)
-
-# request c++11 without gnu extension for the whole project and enable more warnings
-if (CXXOPTS_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD ${CXXOPTS_CXX_STANDARD})
-else()
-  set(CMAKE_CXX_STANDARD 11)
+# Determine whether this is a standalone project or included by other projects
+set(CXXOPTS_STANDALONE_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CXXOPTS_STANDALONE_PROJECT ON)
 endif()
 
-set(CMAKE_CXX_EXTENSIONS OFF)
+# Establish the project options
+option(CXXOPTS_BUILD_EXAMPLES "Set to ON to build examples" ${CXXOPTS_STANDALONE_PROJECT})
+option(CXXOPTS_BUILD_TESTS "Set to ON to build tests" ${CXXOPTS_STANDALONE_PROJECT})
+option(CXXOPTS_ENABLE_INSTALL "Generate the install target" ${CXXOPTS_STANDALONE_PROJECT})
+option(CXXOPTS_ENABLE_WARNINGS "Add warnings to CMAKE_CXX_FLAGS" ${CXXOPTS_STANDALONE_PROJECT})
+option(CXXOPTS_USE_UNICODE_HELP "Use ICU Unicode library" OFF)
+
+if (CXXOPTS_STANDALONE_PROJECT)
+    cxxopts_set_cxx_standard()
+endif()
 
 if (CXXOPTS_ENABLE_WARNINGS)
-if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W2")
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wshadow -Weffc++ -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion -Wsuggest-override")
-endif()
+    cxxopts_enable_warnings()
 endif()
 
 add_library(cxxopts INTERFACE)
 add_library(cxxopts::cxxopts ALIAS cxxopts)
+add_subdirectory(include)
 
-# optionally, enable unicode support using the ICU library
-set(CXXOPTS_USE_UNICODE_HELP FALSE CACHE BOOL "Use ICU Unicode library")
+# Link against the ICU library when requested
 if(CXXOPTS_USE_UNICODE_HELP)
-    find_package(PkgConfig)
-    pkg_check_modules(ICU REQUIRED icu-uc)
-
-    target_link_libraries(cxxopts INTERFACE ${ICU_LDFLAGS})
-    target_compile_options(cxxopts INTERFACE ${ICU_CFLAGS})
-    target_compile_definitions(cxxopts INTERFACE CXXOPTS_USE_UNICODE)
+    cxxopts_use_unicode()
 endif()
 
-target_include_directories(cxxopts INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    )
-
-if(CXXOPTS_ENABLE_INSTALL)
-    include(GNUInstallDirs)
-    include(CMakePackageConfigHelpers)
-    set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/cxxopts" CACHE STRING
-      "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
-    set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")
-    set(project_config "${PROJECT_BINARY_DIR}/cxxopts-config.cmake")
-    set(targets_export_name cxxopts-targets)
-
-    # Generate the version, config and target files into the build directory.
-    write_basic_package_version_file(
-        ${version_config}
-        VERSION ${VERSION}
-        COMPATIBILITY AnyNewerVersion)
-    configure_package_config_file(
-        ${PROJECT_SOURCE_DIR}/cxxopts-config.cmake.in
-        ${project_config}
-        INSTALL_DESTINATION ${CXXOPTS_CMAKE_DIR})
-    export(TARGETS cxxopts NAMESPACE cxxopts::
-        FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
-
-    # Install version, config and target files.
-    install(
-        FILES ${project_config} ${version_config}
-        DESTINATION ${CXXOPTS_CMAKE_DIR})
-    install(EXPORT ${targets_export_name} DESTINATION ${CXXOPTS_CMAKE_DIR}
-        NAMESPACE cxxopts::)
-
-    # Install the header file and export the target
-    install(TARGETS cxxopts EXPORT ${targets_export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(FILES ${PROJECT_SOURCE_DIR}/include/cxxopts.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# Install cxxopts when requested by the user
+if (CXXOPTS_ENABLE_INSTALL)
+    cxxopts_install_logic()
 endif()
 
-add_subdirectory(src)
-add_subdirectory(test)
+# Build examples when requested by the user
+if (CXXOPTS_BUILD_EXAMPLES)
+    add_subdirectory(src)
+endif()
+
+# Enable testing when requested by the user
+if (CXXOPTS_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -22,6 +22,9 @@ if (CMAKE_VERSION VERSION_GREATER 3.10 OR CMAKE_VERSION VERSION_EQUAL 3.10)
     include_guard()
 endif()
 
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 function(cxxopts_getversion version_arg)
     # Parse the current version from the cxxopts header
     file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/cxxopts.hpp" cxxopts_version_defines
@@ -79,8 +82,6 @@ endfunction()
 
 # Helper function to ecapsulate install logic
 function(cxxopts_install_logic)
-    include(GNUInstallDirs)
-    include(CMakePackageConfigHelpers)
     set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/cxxopts" CACHE STRING "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
     set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")
     set(project_config "${PROJECT_BINARY_DIR}/cxxopts-config.cmake")

--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -1,0 +1,111 @@
+# Copyright (c) 2014 Jarryd Beck
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+if (CMAKE_VERSION VERSION_GREATER 3.10 OR CMAKE_VERSION VERSION_EQUAL 3.10)
+    # Use include_guard() added in cmake 3.10
+    include_guard()
+endif()
+
+function(cxxopts_getversion version_arg)
+    # Parse the current version from the cxxopts header
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/cxxopts.hpp" cxxopts_version_defines
+        REGEX "#define CXXOPTS__VERSION_(MAJOR|MINOR|PATCH)")
+    foreach(ver ${cxxopts_version_defines})
+        if(ver MATCHES "#define CXXOPTS__VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+            set(CXXOPTS__VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
+        endif()
+    endforeach()
+    set(VERSION ${CXXOPTS__VERSION_MAJOR}.${CXXOPTS__VERSION_MINOR}.${CXXOPTS__VERSION_PATCH})
+
+    # Give feedback to the user. Prefer DEBUG when available since large projects tend to have a lot
+    # going on already
+    if (CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
+        message(DEBUG "cxxopts version ${VERSION}")
+    else()
+        message(STATUS "cxxopts version ${VERSION}")
+    endif()
+
+    # Return the information to the caller
+    set(${version_arg} ${VERSION} PARENT_SCOPE)
+endfunction()
+
+# Optionally, enable unicode support using the ICU library
+function(cxxopts_use_unicode)
+    find_package(PkgConfig)
+    pkg_check_modules(ICU REQUIRED icu-uc)
+
+    target_link_libraries(cxxopts INTERFACE ${ICU_LDFLAGS})
+    target_compile_options(cxxopts INTERFACE ${ICU_CFLAGS})
+    target_compile_definitions(cxxopts INTERFACE CXXOPTS_USE_UNICODE)
+endfunction()
+
+# Request C++11 without gnu extension for the whole project and enable more warnings
+macro(cxxopts_set_cxx_standard)
+    if (CXXOPTS_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD ${CXXOPTS_CXX_STANDARD})
+    else()
+        set(CMAKE_CXX_STANDARD 11)
+    endif()
+
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endmacro()
+
+# Helper function to enable warnings
+function(cxxopts_enable_warnings)
+    if(MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W2")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wshadow -Weffc++ -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion -Wsuggest-override")
+    endif()
+
+    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} PARENT_SCOPE)
+endfunction()
+
+# Helper function to ecapsulate install logic
+function(cxxopts_install_logic)
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
+    set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/cxxopts" CACHE STRING "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
+    set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")
+    set(project_config "${PROJECT_BINARY_DIR}/cxxopts-config.cmake")
+    set(targets_export_name cxxopts-targets)
+
+    # Generate the version, config and target files into the build directory.
+    write_basic_package_version_file(
+        ${version_config}
+        VERSION ${VERSION}
+        COMPATIBILITY AnyNewerVersion)
+    configure_package_config_file(
+        ${PROJECT_SOURCE_DIR}/cxxopts-config.cmake.in
+        ${project_config}
+        INSTALL_DESTINATION ${CXXOPTS_CMAKE_DIR})
+    export(TARGETS cxxopts NAMESPACE cxxopts::
+        FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
+
+    # Install version, config and target files.
+    install(
+        FILES ${project_config} ${version_config}
+        DESTINATION ${CXXOPTS_CMAKE_DIR})
+    install(EXPORT ${targets_export_name} DESTINATION ${CXXOPTS_CMAKE_DIR}
+        NAMESPACE cxxopts::)
+
+    # Install the header file and export the target
+    install(TARGETS cxxopts EXPORT ${targets_export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${PROJECT_SOURCE_DIR}/include/cxxopts.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endfunction()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
-add_executable(example example.cpp)
-target_link_libraries(example cxxopts)
+target_include_directories(cxxopts INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,35 +1,53 @@
-if (CXXOPTS_BUILD_TESTS)
-    add_executable(options_test main.cpp options.cpp)
-    target_link_libraries(options_test cxxopts)
-    add_test(options options_test)
+# Copyright (c) 2014 Jarryd Beck
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
-    # test if the targets are findable from the build directory
-    add_test(find-package-test ${CMAKE_CTEST_COMMAND}
-        -C ${CMAKE_BUILD_TYPE}
-        --build-and-test
-        "${CMAKE_CURRENT_SOURCE_DIR}/find-package-test"
-        "${CMAKE_CURRENT_BINARY_DIR}/find-package-test"
-        --build-generator ${CMAKE_GENERATOR}
-        --build-makeprogram ${CMAKE_MAKE_PROGRAM}
-        --build-options
-        "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-        "-Dcxxopts_DIR=${PROJECT_BINARY_DIR}"
-    )
+add_executable(options_test main.cpp options.cpp)
+target_link_libraries(options_test cxxopts)
+add_test(options options_test)
 
-    # test if the targets are findable when add_subdirectory is used
-    add_test(add-subdirectory-test ${CMAKE_CTEST_COMMAND}
-        -C ${CMAKE_BUILD_TYPE}
-        --build-and-test
-        "${CMAKE_CURRENT_SOURCE_DIR}/add-subdirectory-test"
-        "${CMAKE_CURRENT_BINARY_DIR}/add-subdirectory-test"
-        --build-generator ${CMAKE_GENERATOR}
-        --build-makeprogram ${CMAKE_MAKE_PROGRAM}
-        --build-options
-        "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-    )
+# test if the targets are findable from the build directory
+add_test(find-package-test ${CMAKE_CTEST_COMMAND}
+    -C ${CMAKE_BUILD_TYPE}
+    --build-and-test
+    "${CMAKE_CURRENT_SOURCE_DIR}/find-package-test"
+    "${CMAKE_CURRENT_BINARY_DIR}/find-package-test"
+    --build-generator ${CMAKE_GENERATOR}
+    --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+    --build-options
+    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    "-Dcxxopts_DIR=${PROJECT_BINARY_DIR}"
+)
 
-    add_executable(link_test link_a.cpp link_b.cpp)
-    target_link_libraries(link_test cxxopts)
-endif()
+# test if the targets are findable when add_subdirectory is used
+add_test(add-subdirectory-test ${CMAKE_CTEST_COMMAND}
+    -C ${CMAKE_BUILD_TYPE}
+    --build-and-test
+    "${CMAKE_CURRENT_SOURCE_DIR}/add-subdirectory-test"
+    "${CMAKE_CURRENT_BINARY_DIR}/add-subdirectory-test"
+    --build-generator ${CMAKE_GENERATOR}
+    --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+    --build-options
+    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+)
+
+add_executable(link_test link_a.cpp link_b.cpp)
+target_link_libraries(link_test cxxopts)


### PR DESCRIPTION
I needed to do a variety of things to ensure cxxopts worked well in my own project.

I created a new cmake module to abstract a lot of the logic in the main CMakelists.txt, I think it really assists in the readability of the project. Consequently a lot of logic is now written in functions.

I tested logic locally with cmake 3.19

I made a lot of the project options off by default unless the project is being built standalone. As a frequent consumer of cmake libraries this is a huge issue. Since examples, tests, installation, etc. aren't things I expect/desired by default when using libraries.

Other than that it's just minor nitpicks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/270)
<!-- Reviewable:end -->
