### PR TITLE
Ignore gcc-10 warning

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1133,12 +1133,21 @@ namespace cxxopts
       m_value->parse();
     }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=null-dereference"
+#endif
+    
     CXXOPTS_NODISCARD
     size_t
     count() const noexcept
     {
       return m_count;
     }
+    
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     // TODO: maybe default options should count towards the number of arguments
     CXXOPTS_NODISCARD


### PR DESCRIPTION
This warning trigger build errors, those pragma are a bit ugly but they prevent the build error.

```
In file included from /home/benjamin.sergeant/src/ALHttp-Cpp/build/_deps/cxxopts-src/src/example.cpp:27:
/home/benjamin.sergeant/src/ALHttp-Cpp/build/_deps/cxxopts-src/include/cxxopts.hpp: In member function ‘size_t cxxopts::ParseResult::count(const string&) const’:
/home/benjamin.sergeant/src/ALHttp-Cpp/build/_deps/cxxopts-src/include/cxxopts.hpp:1027:14: error: potential null pointer dereference [-Werror=null-dereference]
 1027 |       return m_count;
      |              ^~~~~~~
```

This should fix https://github.com/jarro2783/cxxopts/issues/263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/273)
<!-- Reviewable:end -->
