### PR TITLE
Fixing cmake developer warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
             - g++-5
           sources: *sources
 script: >
-    cmake -DCXXOPTS_BUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$COMPILER
+    cmake -Werror=dev -DCXXOPTS_BUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$COMPILER
     -DCMAKE_CXX_FLAGS=$CXXFLAGS $UNICODE_OPTIONS $CMAKE_OPTIONS .
     && make && make ARGS=--output-on-failure test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ project(cxxopts
     LANGUAGES CXX
 )
 
+# Must include after the project call due to GNUInstallDirs requiring a language be enabled (IE. CXX)
+include(GNUInstallDirs)
+
 # Determine whether this is a standalone project or included by other projects
 set(CXXOPTS_STANDALONE_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -22,7 +22,6 @@ if (CMAKE_VERSION VERSION_GREATER 3.10 OR CMAKE_VERSION VERSION_EQUAL 3.10)
     include_guard()
 endif()
 
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 function(cxxopts_getversion version_arg)


### PR DESCRIPTION
Here is the warning currently being produced:

CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.19/Modules/GNUInstallDirs.cmake:223 (message):
Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
target architecture is known. Please enable at least one language before
including GNUInstallDirs.
Call Stack (most recent call first):

I noted how I fixed the error. This is caused by GNUInstallDirs automatically executing code just by including it.

I also added -Werror=dev to the CI to ensure this never happens again.

I didn't catch this error before because I was consuming this project. But if you try to build it standalone you'll get this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/274)
<!-- Reviewable:end -->
