### PR TITLE
Support options like `-j5`.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -2278,6 +2278,12 @@ OptionParser::parse(int argc, const char* const* argv)
           {
             parse_option(value, name, value->value().get_implicit_value());
           }
+          else if (i + 1 < s.size())
+          {
+            std::string arg_value = s.substr(i + 1);
+            parse_option(value, name, arg_value);
+            break;
+          }
           else
           {
             //error

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -779,3 +779,28 @@ TEST_CASE("Const array", "[const]") {
   cxxopts::Options options("Empty options", " - test constness");
   auto result = options.parse(2, option_list);
 }
+
+TEST_CASE("Parameter follow option", "[parameter]") {
+  cxxopts::Options options("param_follow_opt", " - test parameter follow option without space.");
+  options.add_options()
+    ("j,job", "Job", cxxopts::value<std::vector<unsigned>>());
+  Argv av({"implicit",
+      "-j", "9",
+      "--job", "7",
+      "--job=10",
+      "-j5",
+  });
+
+  auto ** argv = av.argv();
+  auto argc = av.argc();
+
+  auto result = options.parse(argc, argv);
+
+  REQUIRE(result.count("job") == 4);
+
+  auto job_values = result["job"].as<std::vector<unsigned>>();
+  CHECK(job_values[0] == 9);
+  CHECK(job_values[1] == 7);
+  CHECK(job_values[2] == 10);
+  CHECK(job_values[3] == 5);
+}


### PR DESCRIPTION
I suggest to support parameter formats like `-j5` to make the input look more GNU style.

I made some minor changes: if a short option is recognized and it requests a parameter, any characters after it are treated as the parameter of the option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/286)
<!-- Reviewable:end -->
