### PR TITLE
Include <optional> if possible to check if we can use the feature

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -51,9 +51,14 @@ THE SOFTWARE.
 #  include <regex>
 #endif  // CXXOPTS_NO_REGEX
 
-#ifdef __cpp_lib_optional
-#include <optional>
-#define CXXOPTS_HAS_OPTIONAL
+// Nonstandard before C++17, which is coincidentally what we also need for <optional>
+#ifdef __has_include
+#  if __has_include(<optional>)
+#    include <optional>
+#    ifdef __cpp_lib_optional
+#      define CXXOPTS_HAS_OPTIONAL
+#    endif
+#  endif
 #endif
 
 #if __cplusplus >= 201603L
@@ -1355,7 +1360,7 @@ namespace cxxopts
     {
       return m_count;
     }
-    
+
 #if defined(CXXOPTS_NULL_DEREF_IGNORE)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Ok, I think I found a fix. I didn't realize `<version>` was a c++20 header. I tested this on gcc 5 and it worked fine, so here's hoping Travis agrees!

Addresses #303
Supercedes #304

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/309)
<!-- Reviewable:end -->
