### PR TITLE
Solve arguments() showing empty keys when exsiting short-only option

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1287,6 +1287,13 @@ namespace cxxopts
       return m_long;
     }
 
+    CXXOPTS_NODISCARD
+    const std::string&
+    essential_name() const
+    {
+      return m_long.empty() ? m_short : m_long;
+    }
+
     size_t
     hash() const
     {
@@ -2150,7 +2157,7 @@ OptionParser::parse_default(const std::shared_ptr<OptionDetails>& details)
   // TODO: remove the duplicate code here
   auto& store = m_parsed[details->hash()];
   store.parse_default(details);
-  m_defaults.emplace_back(details->long_name(), details->value().get_default_value());
+  m_defaults.emplace_back(details->essential_name(), details->value().get_default_value());
 }
 
 inline
@@ -2174,7 +2181,7 @@ OptionParser::parse_option
   auto& result = m_parsed[hash];
   result.parse(value, arg);
 
-  m_sequential.emplace_back(value->long_name(), arg);
+  m_sequential.emplace_back(value->essential_name(), arg);
 }
 
 inline

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -114,6 +114,11 @@ TEST_CASE("Short options", "[options]")
   CHECK(result.count("a") == 1);
   CHECK(result["a"].as<std::string>() == "value");
 
+  auto& arguments = result.arguments();
+  REQUIRE(arguments.size() == 1);
+  CHECK(arguments[0].key() == "a");
+  CHECK(arguments[0].value() == "value");
+
   REQUIRE_THROWS_AS(options.add_options()("", "nothing option"),
     cxxopts::invalid_option_format_error&);
 }
@@ -829,4 +834,55 @@ TEST_CASE("Parameter follow option", "[parameter]") {
   CHECK(job_values[1] == 7);
   CHECK(job_values[2] == 10);
   CHECK(job_values[3] == 5);
+}
+
+TEST_CASE("Iterator", "[iterator]") {
+  cxxopts::Options options("tester", " - test iterating over parse result");
+
+  options.add_options()
+    ("long", "a long option")
+    ("s,short", "a short option")
+    ("a", "a short-only option")
+    ("value", "an option with a value", cxxopts::value<std::string>())
+    ("default", "an option with default value", cxxopts::value<int>()->default_value("42"))
+    ("nothing", "won't exist", cxxopts::value<std::string>())
+    ;
+
+  Argv argv({
+    "tester",
+    "--long",
+    "-s",
+    "-a",
+    "--value",
+    "value",
+  });
+
+  auto** actual_argv = argv.argv();
+  auto argc = argv.argc();
+
+  auto result = options.parse(argc, actual_argv);
+
+  auto iter = result.begin();
+
+  REQUIRE(iter != result.end());
+  CHECK(iter->key() == "long");
+  CHECK(iter->value() == "true");
+
+  REQUIRE(++iter != result.end());
+  CHECK(iter->key() == "short");
+  CHECK(iter->value() == "true");
+
+  REQUIRE(++iter != result.end());
+  CHECK(iter->key() == "a");
+  CHECK(iter->value() == "true");
+
+  REQUIRE(++iter != result.end());
+  CHECK(iter->key() == "value");
+  CHECK(iter->value() == "value");
+
+  REQUIRE(++iter != result.end());
+  CHECK(iter->key() == "default");
+  CHECK(iter->value() == "42");
+  
+  REQUIRE(++iter == result.end());
 }


### PR DESCRIPTION
Solve #317

Before this PR:
```sh
$ ./example --list -x 1        
list = true
 = 1            # expect "x = 1" here
range = false (default)
compile = false (default)
...
```

After:
```sh
$ ./example --list -x 1        
list = true
x = 1          # OK
range = false (default)
compile = false (default)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/318)
<!-- Reviewable:end -->
