### PR TITLE
Fixed cmake lib install path in case of empty CMAKE_LIBRARY_ARCHITECTURE

### DIFF
--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -87,7 +87,12 @@ endfunction()
 
 # Helper function to ecapsulate install logic
 function(cxxopts_install_logic)
-    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+        string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
+    else()
+        # On some systems (e.g. NixOS), `CMAKE_LIBRARY_ARCHITECTURE` can be empty
+        set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
+    endif()
     set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/cxxopts" CACHE STRING "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
     set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")
     set(project_config "${PROJECT_BINARY_DIR}/cxxopts-config.cmake")


### PR DESCRIPTION
In case `CMAKE_LIBRARY_ARCHITECTURE` is empty (e.g. on NixOS), the replace pattern for `CMAKE_INSTALL_LIBDIR_ARCHIND` would replace all slashes in `CMAKE_INSTALL_LIBDIR` path. The best way would be to leave that path as is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/322)
<!-- Reviewable:end -->
