### PR TITLE
Derive `option_has_no_value_exception` from `OptionParseException`

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -491,11 +491,11 @@ namespace cxxopts
     }
   };
 
-  class option_has_no_value_exception : public OptionException
+  class option_has_no_value_exception : public OptionParseException
   {
     public:
     explicit option_has_no_value_exception(const std::string& option)
-    : OptionException(
+    : OptionParseException(
         !option.empty() ?
         ("Option " + LQUOTE + option + RQUOTE + " has no value") :
         "Option has no value")


### PR DESCRIPTION
Implements #327.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/328)
<!-- Reviewable:end -->
