### PR TITLE
Parse command line arguments as a std::string

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ To parse the command line do:
 auto result = options.parse(argc, argv);
 ```
 
+Or if you have all the arguments of `argv` in a `std::string`, separated by
+white spaces, do:
+
+```cpp
+auto result = options.parse(argv_str);
+```
+
+Note the support for string parsing is limited. No bash variable replacement and
+wild card expansion.
+
 To retrieve an option use `result.count("option")` to get the number of times
 it appeared, and
 

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1773,7 +1773,7 @@ namespace cxxopts
     parse(int argc, const char* const* argv);
 
     ParseResult
-    parse(std::string argv_str);
+    parse(const std::string& argv_str);
 
     OptionAdder
     add_options(std::string group = "");
@@ -2289,7 +2289,7 @@ Options::parse(int argc, const char* const* argv)
 
 inline
 ParseResult
-Options::parse(std::string argv_str)
+Options::parse(const std::string& argv_str)
 {
   std::vector<std::string> tokens;
   std::string token;
@@ -2299,15 +2299,14 @@ Options::parse(std::string argv_str)
     tokens.push_back(token);
   }
 
-  const char** argv = new const char*[tokens.size()];
-  for (int i = 0; i < tokens.size(); ++i) {
+  std::unique_ptr<const char*[]> argv(new const char*[tokens.size()]);
+  for (std::size_t i = 0; i < tokens.size(); ++i) {
     argv[i] = tokens[i].c_str();
   }
 
   OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
 
-  auto parse_result = parser.parse(tokens.size(), argv);
-  delete argv;
+  auto parse_result = parser.parse(static_cast<int>(tokens.size()), argv.get());
   return parse_result;
 }
 

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1772,6 +1772,9 @@ namespace cxxopts
     ParseResult
     parse(int argc, const char* const* argv);
 
+    ParseResult
+    parse(std::string argv_str);
+
     OptionAdder
     add_options(std::string group = "");
 
@@ -2282,6 +2285,30 @@ Options::parse(int argc, const char* const* argv)
   OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
 
   return parser.parse(argc, argv);
+}
+
+inline
+ParseResult
+Options::parse(std::string argv_str)
+{
+  std::vector<std::string> tokens;
+  std::string token;
+  std::istringstream iss(argv_str);
+  while (std::getline(iss, token, ' '))
+  {
+    tokens.push_back(token);
+  }
+
+  const char** argv = new const char*[tokens.size()];
+  for (int i = 0; i < tokens.size(); ++i) {
+    argv[i] = tokens[i].c_str();
+  }
+
+  OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
+
+  auto parse_result = parser.parse(tokens.size(), argv);
+  delete argv;
+  return parse_result;
 }
 
 inline ParseResult

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "cxxopts.hpp"
 
 void
-parse(int argc, const char* argv[])
+parse(int argc, const char* argv[], bool parse_as_string = false)
 {
   try
   {
@@ -77,7 +77,20 @@ parse(int argc, const char* argv[])
 
     options.parse_positional({"input", "output", "positional"});
 
-    auto result = options.parse(argc, argv);
+    cxxopts::ParseResult result;
+    if (parse_as_string)
+    {
+        std::string argv_str;
+        for (int i = 0; i < argc; ++i)
+        {
+            argv_str += std::string(argv[i]) + std::string(" ");
+        }
+        result = options.parse(argv_str);
+    }
+    else
+    {
+        result = options.parse(argc, argv);
+    }
 
     if (result.count("help"))
     {
@@ -184,6 +197,9 @@ parse(int argc, const char* argv[])
 int main(int argc, const char* argv[])
 {
   parse(argc, argv);
+
+  // Parse argv as string
+  parse(argc, argv, true);
 
   return 0;
 }

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "cxxopts.hpp"
 
 void
-parse(int argc, const char* argv[], bool parse_as_string = false)
+parse(int argc, const char* argv[])
 {
   try
   {
@@ -77,20 +77,7 @@ parse(int argc, const char* argv[], bool parse_as_string = false)
 
     options.parse_positional({"input", "output", "positional"});
 
-    cxxopts::ParseResult result;
-    if (parse_as_string)
-    {
-        std::string argv_str;
-        for (int i = 0; i < argc; ++i)
-        {
-            argv_str += std::string(argv[i]) + std::string(" ");
-        }
-        result = options.parse(argv_str);
-    }
-    else
-    {
-        result = options.parse(argc, argv);
-    }
+    auto result = options.parse(argc, argv);
 
     if (result.count("help"))
     {
@@ -197,9 +184,6 @@ parse(int argc, const char* argv[], bool parse_as_string = false)
 int main(int argc, const char* argv[])
 {
   parse(argc, argv);
-
-  // Parse argv as string
-  parse(argc, argv, true);
 
   return 0;
 }


### PR DESCRIPTION
A straightforward implementation for #329. Works fine for enabling local program to be called from browser via system protocols. Known limitation includes no bash variable and wildcard expansion. Haven't tested for corner cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/330)
<!-- Reviewable:end -->
