### PR TITLE
Add option to display usage

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -2725,10 +2725,13 @@ Options::generate_all_groups_help(String& result) const
 
 inline
 std::string
-Options::help(const std::vector<std::string>& help_groups) const
+Options::help(const std::vector<std::string>& help_groups, bool print_usage=true) const
 {
-  String result = m_help_string + "\nUsage:\n  " +
-    toLocalString(m_program) + " " + toLocalString(m_custom_help);
+  String result = m_help_string;
+  if(print_usage)
+  {
+    result+= "\nUsage:\n  " + toLocalString(m_program) + " " + toLocalString(m_custom_help);
+  }
 
   if (!m_positional.empty() && !m_positional_help.empty()) {
     result += " " + toLocalString(m_positional_help);

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -2725,7 +2725,7 @@ Options::generate_all_groups_help(String& result) const
 
 inline
 std::string
-Options::help(const std::vector<std::string>& help_groups, bool print_usage=true) const
+Options::help(const std::vector<std::string>& help_groups, bool print_usage) const
 {
   String result = m_help_string;
   if(print_usage)

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1893,7 +1893,7 @@ class Options
   }
 
   std::string
-  help(const std::vector<std::string>& groups = {}) const;
+  help(const std::vector<std::string>& groups = {}, bool print_usage=true) const;
 
   std::vector<std::string>
   groups() const;


### PR DESCRIPTION
Make the usage displaying optional.

This was necessary for one of our projects since we had a custom usage for the program; we expected input from the standard output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/355)
<!-- Reviewable:end -->
