### PR TITLE
Extend CI and small fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
-        compiler: [ g++-7, g++-9, g++-10, clang++ ]
+        compiler: [ g++-9, g++-10, clang++ ]
+        include:
+          - os: ubuntu-18.04
+            compiler: g++-7
     name: Build and Test on Ubuntu
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
   workflow_dispatch:
 
 env:
@@ -12,33 +12,47 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ${{matrix.os}}
-
+  build-ubuntu:
     strategy:
       matrix:
-        os: [ubuntu-18.04]
-        compiler: [g++-7, g++-9, g++-10, clang++]
-         
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        compiler: [ g++-7, g++-9, g++-10, clang++ ]
+    name: Build and Test on Ubuntu
+    runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Configure CMake
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+      - name: Build
+        run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
+      - name: Test
+        working-directory: ${{github.workspace}}/build/test
+        run: ctest -C $BUILD_TYPE --output-on-failure
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+  build-macos:
+    name: Build and Test on MacOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure CMake
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: Build
+        run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
+      - name: Test
+        working-directory: ${{github.workspace}}/build/test
+        shell: bash
+        run: ctest -C $BUILD_TYPE --output-on-failure
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
-      
+  build-windows:
+    name: Build and Test on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure CMake
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl"
+      - name: Build
+        run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
+      - name: Test
+        working-directory: ${{github.workspace}}/build/test
+        run: cd $BUILD_TYPE && ./link_test && ./options_test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -39,7 +39,10 @@ jobs:
 
   build-macos:
     name: Build and Test on MacOS
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ macos-11, macos-12 ]
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
       - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure CMake
-        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Show compile commands
+        run: cat build/compile_commands.json
       - name: Build
         run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
       - name: Test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,6 +11,11 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-ubuntu:
     strategy:

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1914,13 +1914,13 @@ format_description
   while (current != std::end(desc))
   {
     appendNewLine = false;
-
-    if (std::isblank(*previous, std::locale::classic()))
+    const char prev = *previous;
+    if (std::isblank(prev, std::locale::classic()))
     {
       lastSpace = current;
     }
-
-    if (!std::isblank(*current, std::locale::classic()))
+    const char curr = *current;
+    if (!std::isblank(curr, std::locale::classic()))
     {
       onlyWhiteSpace = false;
     }

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -30,8 +30,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <exception>
 #include <limits>
-#include <list>
-#include <locale>
+#include <initializer_list>
 #include <map>
 #include <memory>
 #include <regex>

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -27,34 +27,25 @@ THE SOFTWARE.
 #ifndef CXXOPTS_HPP_INCLUDED
 #define CXXOPTS_HPP_INCLUDED
 
-#include <cstring>
+#include <algorithm>
 #include <exception>
 #include <limits>
 #include <list>
 #include <locale>
 #include <map>
 #include <memory>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <algorithm>
 
 #ifdef CXXOPTS_NO_EXCEPTIONS
 #include <iostream>
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
-#  if (__GNUC__ * 10 + __GNUC_MINOR__) < 49
-#    define CXXOPTS_NO_REGEX true
-#  endif
-#endif
-
-#ifndef CXXOPTS_NO_REGEX
-#  include <regex>
-#endif  // CXXOPTS_NO_REGEX
 
 // Nonstandard before C++17, which is coincidentally what we also need for <optional>
 #ifdef __has_include
@@ -580,168 +571,6 @@ struct ArguDesc {
   std::string value     = "";
 };
 
-#ifdef CXXOPTS_NO_REGEX
-inline IntegerDesc SplitInteger(const std::string &text)
-{
-  if (text.empty())
-  {
-    throw_or_mimic<exceptions::incorrect_argument_type>(text);
-  }
-  IntegerDesc desc;
-  const char *pdata = text.c_str();
-  if (*pdata == '-')
-  {
-    pdata += 1;
-    desc.negative = "-";
-  }
-  if (strncmp(pdata, "0x", 2) == 0)
-  {
-    pdata += 2;
-    desc.base = "0x";
-  }
-  if (*pdata != '\0')
-  {
-    desc.value = std::string(pdata);
-  }
-  else
-  {
-    throw_or_mimic<exceptions::incorrect_argument_type>(text);
-  }
-  return desc;
-}
-
-inline bool IsTrueText(const std::string &text)
-{
-  const char *pdata = text.c_str();
-  if (*pdata == 't' || *pdata == 'T')
-  {
-    pdata += 1;
-    if (strncmp(pdata, "rue\0", 4) == 0)
-    {
-      return true;
-    }
-  }
-  else if (strncmp(pdata, "1\0", 2) == 0)
-  {
-    return true;
-  }
-  return false;
-}
-
-inline bool IsFalseText(const std::string &text)
-{
-  const char *pdata = text.c_str();
-  if (*pdata == 'f' || *pdata == 'F')
-  {
-    pdata += 1;
-    if (strncmp(pdata, "alse\0", 5) == 0)
-    {
-      return true;
-    }
-  }
-  else if (strncmp(pdata, "0\0", 2) == 0)
-  {
-    return true;
-  }
-  return false;
-}
-
-inline OptionNames split_option_names(const std::string &text)
-{
-  OptionNames split_names;
-
-  std::string::size_type token_start_pos = 0;
-  auto length = text.length();
-
-  if (length == 0)
-  {
-    throw_or_mimic<exceptions::invalid_option_format>(text);
-  }
-
-  while (token_start_pos < length) {
-    const auto &npos = std::string::npos;
-    auto next_non_space_pos = text.find_first_not_of(' ', token_start_pos);
-    if (next_non_space_pos == npos) {
-      throw_or_mimic<exceptions::invalid_option_format>(text);
-    }
-    token_start_pos = next_non_space_pos;
-    auto next_delimiter_pos = text.find(',', token_start_pos);
-    if (next_delimiter_pos == token_start_pos) {
-      throw_or_mimic<exceptions::invalid_option_format>(text);
-    }
-    if (next_delimiter_pos == npos) {
-      next_delimiter_pos = length;
-    }
-    auto token_length = next_delimiter_pos - token_start_pos;
-    // validate the token itself matches the regex /([:alnum:][-_[:alnum:]]*/
-    {
-      const char* option_name_valid_chars =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        "abcdefghijklmnopqrstuvwxyz"
-        "0123456789"
-        "_-";
-      if (!std::isalnum(text[token_start_pos], std::locale::classic()) ||
-          text.find_first_not_of(option_name_valid_chars, token_start_pos) < next_delimiter_pos) {
-        throw_or_mimic<exceptions::invalid_option_format>(text);
-      }
-    }
-    split_names.emplace_back(text.substr(token_start_pos, token_length));
-    token_start_pos = next_delimiter_pos + 1;
-  }
-  return split_names;
-}
-
-inline ArguDesc ParseArgument(const char *arg, bool &matched)
-{
-  ArguDesc argu_desc;
-  const char *pdata = arg;
-  matched = false;
-  if (strncmp(pdata, "--", 2) == 0)
-  {
-    pdata += 2;
-    if (isalnum(*pdata, std::locale::classic()))
-    {
-      argu_desc.arg_name.push_back(*pdata);
-      pdata += 1;
-      while (isalnum(*pdata, std::locale::classic()) || *pdata == '-' || *pdata == '_')
-      {
-        argu_desc.arg_name.push_back(*pdata);
-        pdata += 1;
-      }
-      if (argu_desc.arg_name.length() > 1)
-      {
-        if (*pdata == '=')
-        {
-          argu_desc.set_value = true;
-          pdata += 1;
-          if (*pdata != '\0')
-          {
-            argu_desc.value = std::string(pdata);
-          }
-          matched = true;
-        }
-        else if (*pdata == '\0')
-        {
-          matched = true;
-        }
-      }
-    }
-  }
-  else if (strncmp(pdata, "-", 1) == 0)
-  {
-    pdata += 1;
-    argu_desc.grouping = true;
-    while (isalnum(*pdata, std::locale::classic()))
-    {
-      argu_desc.arg_name.push_back(*pdata);
-      pdata += 1;
-    }
-    matched = !argu_desc.arg_name.empty() && *pdata == '\0';
-  }
-  return argu_desc;
-}
-
-#else  // CXXOPTS_NO_REGEX
 
 namespace {
 
@@ -838,9 +667,6 @@ inline ArguDesc ParseArgument(const char *arg, bool &matched)
 
   return argu_desc;
 }
-
-#endif  // CXXOPTS_NO_REGEX
-#undef CXXOPTS_NO_REGEX
 } // namespace parser_tool
 
 namespace detail {
@@ -2368,7 +2194,7 @@ OptionParser::parse(int argc, const char* const* argv)
 
   while (current != argc)
   {
-    if (strcmp(argv[current], "--") == 0)
+    if (std::string{argv[current]} == "--")
     {
       consume_remaining = true;
       ++current;

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -185,9 +185,9 @@ stringAppend(String&s, String a)
 
 inline
 String&
-stringAppend(String& s, size_t n, UChar32 c)
+stringAppend(String& s, std::size_t n, UChar32 c)
 {
-  for (size_t i = 0; i != n; ++i)
+  for (std::size_t i = 0; i != n; ++i)
   {
     s.append(c);
   }
@@ -209,7 +209,7 @@ stringAppend(String& s, Iterator begin, Iterator end)
 }
 
 inline
-size_t
+std::size_t
 stringLength(const String& s)
 {
   return s.length();
@@ -267,7 +267,7 @@ toLocalString(T&& t)
 }
 
 inline
-size_t
+std::size_t
 stringLength(const String& s)
 {
   return s.length();
@@ -282,7 +282,7 @@ stringAppend(String&s, const String& a)
 
 inline
 String&
-stringAppend(String& s, size_t n, char c)
+stringAppend(String& s, std::size_t n, char c)
 {
   return s.append(n, c);
 }
@@ -1180,7 +1180,7 @@ class OptionDetails
     return m_long;
   }
 
-  size_t
+  std::size_t
   hash() const
   {
     return m_hash;
@@ -1193,7 +1193,7 @@ class OptionDetails
   std::shared_ptr<const Value> m_value{};
   int m_count;
 
-  size_t m_hash{};
+  std::size_t m_hash{};
 };
 
 struct HelpOptionDetails
@@ -1254,7 +1254,7 @@ CXXOPTS_IGNORE_WARNING("-Wnull-dereference")
 #endif
 
   CXXOPTS_NODISCARD
-  size_t
+  std::size_t
   count() const noexcept
   {
     return m_count;
@@ -1299,7 +1299,7 @@ CXXOPTS_DIAGNOSTIC_POP
   // Holding this pointer is safe, since OptionValue's only exist in key-value pairs,
   // where the key has the string we point to.
   std::shared_ptr<Value> m_value{};
-  size_t m_count = 0;
+  std::size_t m_count = 0;
   bool m_default = false;
 };
 
@@ -1340,8 +1340,8 @@ class KeyValue
   std::string m_value;
 };
 
-using ParsedHashMap = std::unordered_map<size_t, OptionValue>;
-using NameHashMap = std::unordered_map<std::string, size_t>;
+using ParsedHashMap = std::unordered_map<std::size_t, OptionValue>;
+using NameHashMap = std::unordered_map<std::string, std::size_t>;
 
 class ParseResult
 {
@@ -1435,7 +1435,7 @@ class ParseResult
     return Iterator(this, true);
   }
 
-  size_t
+  std::size_t
   count(const std::string& o) const
   {
     auto iter = m_keys.find(o);
@@ -1645,7 +1645,7 @@ class Options
   }
 
   Options&
-  set_width(size_t width)
+  set_width(std::size_t width)
   {
     m_width = width;
     return *this;
@@ -1763,7 +1763,7 @@ class Options
   std::string m_positional_help{};
   bool m_show_positional;
   bool m_allow_unrecognised;
-  size_t m_width;
+  std::size_t m_width;
   bool m_tab_expansion;
 
   std::shared_ptr<OptionMap> m_options;
@@ -1799,8 +1799,8 @@ class OptionAdder
 };
 
 namespace {
-constexpr size_t OPTION_LONGEST = 30;
-constexpr size_t OPTION_DESC_GAP = 2;
+constexpr std::size_t OPTION_LONGEST = 30;
+constexpr std::size_t OPTION_DESC_GAP = 2;
 
 String
 format_option
@@ -1852,8 +1852,8 @@ String
 format_description
 (
   const HelpOptionDetails& o,
-  size_t start,
-  size_t allowed,
+  std::size_t start,
+  std::size_t allowed,
   bool tab_expansion
 )
 {
@@ -1876,7 +1876,7 @@ format_description
   if (tab_expansion)
   {
     String desc2;
-    auto size = size_t{ 0 };
+    auto size = std::size_t{ 0 };
     for (auto c = std::begin(desc); c != std::end(desc); ++c)
     {
       if (*c == '\n')
@@ -1906,7 +1906,7 @@ format_description
   auto startLine = current;
   auto lastSpace = current;
 
-  auto size = size_t{};
+  auto size = std::size_t{};
 
   bool appendNewLine;
   bool onlyWhiteSpace = true;
@@ -1914,13 +1914,11 @@ format_description
   while (current != std::end(desc))
   {
     appendNewLine = false;
-    const char prev = *previous;
-    if (std::isblank(prev, std::locale::classic()))
+    if (*previous == ' ' || *previous == '\t')
     {
       lastSpace = current;
     }
-    const char curr = *current;
-    if (!std::isblank(curr, std::locale::classic()))
+    if (*current != ' ' && *current != '\t')
     {
       onlyWhiteSpace = false;
     }
@@ -2446,7 +2444,7 @@ Options::help_one_group(const std::string& g) const
 
   OptionHelp format;
 
-  size_t longest = 0;
+  std::size_t longest = 0;
 
   String result;
 
@@ -2471,7 +2469,7 @@ Options::help_one_group(const std::string& g) const
   longest = (std::min)(longest, OPTION_LONGEST);
 
   //widest allowed description -- min 10 chars for helptext/line
-  size_t allowed = 10;
+  std::size_t allowed = 10;
   if (m_width > allowed + longest + OPTION_DESC_GAP)
   {
     allowed = m_width - longest - OPTION_DESC_GAP;
@@ -2518,7 +2516,7 @@ Options::generate_group_help
   const std::vector<std::string>& print_groups
 ) const
 {
-  for (size_t i = 0; i != print_groups.size(); ++i)
+  for (std::size_t i = 0; i != print_groups.size(); ++i)
   {
     const String& group_help_text = help_one_group(print_groups[i]);
     if (empty(group_help_text))

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -2091,12 +2091,12 @@ format_description
   {
     appendNewLine = false;
 
-    if (std::isblank(*previous, std::locale::classic()))
+    if (std::isblank<char>(*previous, std::locale::classic()))
     {
       lastSpace = current;
     }
 
-    if (!std::isblank(*current, std::locale::classic()))
+    if (!std::isblank<char>(*current, std::locale::classic()))
     {
       onlyWhiteSpace = false;
     }

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #define CXXOPTS_HPP_INCLUDED
 
 #include <cassert>
-#include <cctype>
 #include <cstring>
 #include <exception>
 #include <limits>
@@ -682,7 +681,7 @@ inline OptionNames split_option_names(const std::string &text)
         "abcdefghijklmnopqrstuvwxyz"
         "0123456789"
         "_-";
-      if (!std::isalnum(text[token_start_pos]) ||
+      if (!std::isalnum(text[token_start_pos], std::locale::classic()) ||
           text.find_first_not_of(option_name_valid_chars, token_start_pos) < next_delimiter_pos) {
         throw_or_mimic<exceptions::invalid_option_format>(text);
       }
@@ -701,11 +700,11 @@ inline ArguDesc ParseArgument(const char *arg, bool &matched)
   if (strncmp(pdata, "--", 2) == 0)
   {
     pdata += 2;
-    if (isalnum(*pdata))
+    if (isalnum(*pdata, std::locale::classic()))
     {
       argu_desc.arg_name.push_back(*pdata);
       pdata += 1;
-      while (isalnum(*pdata) || *pdata == '-' || *pdata == '_')
+      while (isalnum(*pdata, std::locale::classic()) || *pdata == '-' || *pdata == '_')
       {
         argu_desc.arg_name.push_back(*pdata);
         pdata += 1;
@@ -733,7 +732,7 @@ inline ArguDesc ParseArgument(const char *arg, bool &matched)
   {
     pdata += 1;
     argu_desc.grouping = true;
-    while (isalnum(*pdata))
+    while (isalnum(*pdata, std::locale::classic()))
     {
       argu_desc.arg_name.push_back(*pdata);
       pdata += 1;
@@ -2091,12 +2090,12 @@ format_description
   {
     appendNewLine = false;
 
-    if (std::isblank<char>(*previous, std::locale::classic()))
+    if (std::isblank(*previous, std::locale::classic()))
     {
       lastSpace = current;
     }
 
-    if (!std::isblank<char>(*current, std::locale::classic()))
+    if (!std::isblank(*current, std::locale::classic()))
     {
       onlyWhiteSpace = false;
     }

--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -27,7 +27,6 @@ THE SOFTWARE.
 #ifndef CXXOPTS_HPP_INCLUDED
 #define CXXOPTS_HPP_INCLUDED
 
-#include <cassert>
 #include <cstring>
 #include <exception>
 #include <limits>


### PR DESCRIPTION
This PR includes quite a few changes, mostly the extended CI now also builds and tests for MacOS as well as Windows ~~and the `<regexp>` header is now always assumed to be available since cxxopts requires c++11~~.

Smaller changes in this PR are:

- Remove reliance on `std::isblank(charT, locale)` so builds on MacOS work again. (fixes #369 )
- CI runs on `master` as well as `main` in case the default branch is changed in the future
- Remove some unused headers
- Add `std::` to instances of `size_t`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/370)
<!-- Reviewable:end -->
