### PR TITLE
Fix an additional space in help generated

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -2742,7 +2742,12 @@ Options::help(const std::vector<std::string>& help_groups, bool print_usage) con
   String result = m_help_string;
   if(print_usage)
   {
-    result+= "\nUsage:\n  " + toLocalString(m_program) + " " + toLocalString(m_custom_help);
+    result+= "\nUsage:\n  " + toLocalString(m_program);
+  }
+
+  if (!m_custom_help.empty())
+  {
+    result += " " + toLocalString(m_custom_help);
   }
 
   if (!m_positional.empty() && !m_positional_help.empty()) {

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -918,3 +918,27 @@ TEST_CASE("Iterator", "[iterator]") {
   
   REQUIRE(++iter == result.end());
 }
+
+TEST_CASE("No Options help", "[options]")
+{
+  std::vector<std::string> positional;
+
+  cxxopts::Options options("test", "test no options help");
+
+  // explicitly setting custom help empty to overwrite
+  // default "[OPTION...]" when there are no options
+  options.positional_help("<posArg1>...<posArgN>")
+    .custom_help("")
+    .add_options()
+      ("positional", "", cxxopts::value<std::vector<std::string>>(positional));
+
+  Argv av({"test", "posArg1", "posArg2", "posArg3"});
+
+  auto argc   = av.argc();
+  auto** argv = av.argv();
+
+  options.parse_positional({"positional"});
+
+  CHECK_NOTHROW(options.parse(argc, argv));
+  CHECK(options.help().find("test <posArg1>...<posArgN>") != std::string::npos);
+}


### PR DESCRIPTION
### Problem: 
In the scenario when command line args don't have any options and have only positional args. The help generated shows an extra space when we try to set custom help to `empty string` in order to overwrite the default `[OPTION...]` string in the help.

```
cxxopts::Options options{"test", ""};
std::vector<std::string> positional;
options
  .positional_help("<posArg1>...<posArgN>")
  .custom_help("")
  .add_options()
    ("positional", "", cxxopts::value<std::vector<std::string>>(positional));

options.parse_positional({"positional"});
std::vector<const char*> arg = {"pos1", "pos2", "pos3"};
auto r = o.parse(arg.size(), arg.data());
cout<<options.help();
```

### Current generated help
```
Usage:
  test  <posArg1>...<posArgN>
```
Note: there are 2 spaces between `test` and `<posArg1>`
### Expected help
```
Usage:
  test <posArg1>...<posArgN>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/377)
<!-- Reviewable:end -->
