### PR TITLE
Fix noexcept warning

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1498,7 +1498,7 @@ CXXOPTS_DIAGNOSTIC_POP
 class KeyValue
 {
   public:
-  KeyValue(std::string key_, std::string value_)
+  KeyValue(std::string key_, std::string value_) noexcept
   : m_key(std::move(key_))
   , m_value(std::move(value_))
   {


### PR DESCRIPTION
Fixes a warning when compiling with gcc with C++20 and `-Wnoexcept`  enabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/391)
<!-- Reviewable:end -->
