### PR TITLE
Output same exception messages for both Linux and Windows

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -337,13 +337,8 @@ empty(const std::string& s)
 namespace cxxopts {
 
 namespace {
-#ifdef _WIN32
 CXXOPTS_LINKONCE_CONST std::string LQUOTE("\'");
 CXXOPTS_LINKONCE_CONST std::string RQUOTE("\'");
-#else
-CXXOPTS_LINKONCE_CONST std::string LQUOTE("‘");
-CXXOPTS_LINKONCE_CONST std::string RQUOTE("’");
-#endif
 } // namespace
 
 // GNU GCC with -Weffc++ will issue a warning regarding the upcoming class, we


### PR DESCRIPTION
While it is indeed pleasing to see UTF-8 output on Linux, we strongly prefer cross-platform consistency to help with testing.

If this approach  is too heavy-handed, I could refactor with some sort of opt-out for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/395)
<!-- Reviewable:end -->
