### PR TITLE
Fix ordering of parse_value functions

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1062,6 +1062,28 @@ parse_value(const std::string& text, T& value) {
   stringstream_parser(text, value);
 }
 
+#ifdef CXXOPTS_HAS_OPTIONAL
+template <typename T>
+void
+parse_value(const std::string& text, std::optional<T>& value)
+{
+  T result;
+  parse_value(text, result);
+  value = std::move(result);
+}
+#endif
+
+inline
+void parse_value(const std::string& text, char& c)
+{
+  if (text.length() != 1)
+  {
+    throw_or_mimic<exceptions::incorrect_argument_type>(text);
+  }
+
+  c = text[0];
+}
+
 template <typename T>
 void
 parse_value(const std::string& text, std::vector<T>& value)
@@ -1095,28 +1117,6 @@ add_value(const std::string& text, std::vector<T>& value)
   T v;
   add_value(text, v);
   value.emplace_back(std::move(v));
-}
-
-#ifdef CXXOPTS_HAS_OPTIONAL
-template <typename T>
-void
-parse_value(const std::string& text, std::optional<T>& value)
-{
-  T result;
-  parse_value(text, result);
-  value = std::move(result);
-}
-#endif
-
-inline
-void parse_value(const std::string& text, char& c)
-{
-  if (text.length() != 1)
-  {
-    throw_or_mimic<exceptions::incorrect_argument_type>(text);
-  }
-
-  c = text[0];
 }
 
 template <typename T>

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -709,11 +709,13 @@ TEST_CASE("std::vector", "[vector]") {
 #ifdef CXXOPTS_HAS_OPTIONAL
 TEST_CASE("std::optional", "[optional]") {
   std::optional<std::string> optional;
+  std::optional<bool> opt_bool;
   cxxopts::Options options("optional", " - tests optional");
   options.add_options()
-    ("optional", "an optional option", cxxopts::value<std::optional<std::string>>(optional));
+    ("optional", "an optional option", cxxopts::value<std::optional<std::string>>(optional))
+    ("optional_bool", "an boolean optional", cxxopts::value<std::optional<bool>>(opt_bool)->default_value("false"));
 
-  Argv av({"optional", "--optional", "foo"});
+  Argv av({"optional", "--optional", "foo", "--optional_bool", "true"});
 
   auto** argv = av.argv();
   auto argc = av.argc();
@@ -722,6 +724,8 @@ TEST_CASE("std::optional", "[optional]") {
 
   REQUIRE(optional.has_value());
   CHECK(*optional == "foo");
+  CHECK(opt_bool.has_value());
+  CHECK(*opt_bool);
 }
 #endif
 


### PR DESCRIPTION
Fixes #419. Put the definitions of parse_value functions before they are called so that the right ones are chosen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/420)
<!-- Reviewable:end -->
