### PR TITLE
Extend cxxopts API to support std::optional non-throwing query of values

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1538,6 +1538,15 @@ CXXOPTS_DIAGNOSTIC_POP
     return CXXOPTS_RTTI_CAST<const values::standard_value<T>&>(*m_value).get();
   }
 
+#ifdef CXXOPTS_HAS_OPTIONAL
+  template <typename T>
+  std::optional<T>
+  as_optional() const
+  {
+    return as<T>();
+  }
+#endif
+
   private:
   void
   ensure_value(const std::shared_ptr<const OptionDetails>& details)
@@ -1749,6 +1758,24 @@ CXXOPTS_DIAGNOSTIC_POP
 
     return viter->second;
   }
+
+#ifdef CXXOPTS_HAS_OPTIONAL
+  template <typename T>
+  std::optional<T>
+  as_optional(const std::string& option) const
+  {
+    auto iter = m_keys.find(option);
+    if (iter != m_keys.end())
+    {
+      auto viter = m_values.find(iter->second);
+      if (viter != m_values.end())
+      {
+        return viter->second.as_optional<T>();
+      }
+    }
+    return std::nullopt;
+  }
+#endif
 
   const std::vector<KeyValue>&
   arguments() const

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -821,6 +821,57 @@ TEST_CASE("Options empty", "[options]") {
   CHECK_THROWS_AS(options.parse(argc, argv), cxxopts::exceptions::no_such_option);
 }
 
+#ifdef CXXOPTS_HAS_OPTIONAL
+TEST_CASE("Optional value", "[optional]")
+{
+  cxxopts::Options options("options", "query as std::optional");
+  options.add_options()
+    ("int", "Integer", cxxopts::value<int>())
+    ("float", "Float", cxxopts::value<float>())
+    ("string", "String", cxxopts::value<std::string>())
+    ;
+
+  SECTION("Available") {
+    Argv av({
+      "--int",
+      "42",
+      "--float",
+      "3.141",
+      "--string",
+      "Hello"
+    });
+
+    auto** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+
+    CHECK(result.as_optional<int>("int"));
+    CHECK(result.as_optional<float>("float"));
+    CHECK(result.as_optional<string>("string"));
+
+    CHECK(*result.as_optional<int>("int") == 42);
+    CHECK(*result.as_optional<float>("float") == 3.141);
+    CHECK(*result.as_optional<string>("string") == "Hello");
+  }
+
+  SECTION("Unavailable") {
+    Argv av({
+    });
+
+    auto** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+
+    CHECK(!result.as_optional<int>("int"));
+    CHECK(!result.as_optional<float>("float"));
+    CHECK(!result.as_optional<string>("string"));
+  }
+
+}
+#endif
+
 TEST_CASE("Initializer list with group", "[options]") {
   cxxopts::Options options("Initializer list group", " - test initializer list with group");
 


### PR DESCRIPTION
We have some internal usage of `std::optional` that can integrate very tidily with cxxopts providing this query for `std::optional` value of given name and type.

No need for an if-check of `count` or catching an exception.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/421)
<!-- Reviewable:end -->
