### PR TITLE
Fix a number of packaging issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,6 @@ cmake_minimum_required(VERSION 3.1...3.19)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 include(cxxopts)
-set("PROJECT_DESCRIPTION" "A header-only lightweight C++ command line option parser")
-set("PROJECT_HOMEPAGE_URL" "https://github.com/jarro2783/cxxopts")
 
 # Get the version of the library
 cxxopts_getversion(VERSION)
@@ -31,6 +29,9 @@ project(cxxopts
     VERSION "${VERSION}"
     LANGUAGES CXX
 )
+
+set("PROJECT_DESCRIPTION" "A header-only lightweight C++ command line option parser")
+set("PROJECT_HOMEPAGE_URL" "https://github.com/jarro2783/cxxopts")
 
 # Must include after the project call due to GNUInstallDirs requiring a language be enabled (IE. CXX)
 include(GNUInstallDirs)

--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -87,22 +87,24 @@ endfunction()
 
 # Helper function to ecapsulate install logic
 function(cxxopts_install_logic)
-    if(CMAKE_LIBRARY_ARCHITECTURE)
-        string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
+    if(NOT CXXOPTS_USE_UNICODE_HELP)
+        if(CMAKE_LIBRARY_ARCHITECTURE)
+            string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
+        else()
+            # On some systems (e.g. NixOS), `CMAKE_LIBRARY_ARCHITECTURE` can be empty
+            set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_DATAROOTDIR}")
+        endif()
+        if(${CMAKE_VERSION} VERSION_GREATER "3.14")
+            set(OPTIONAL_ARCH_INDEPENDENT "ARCH_INDEPENDENT")
+        endif()
     else()
-        # On some systems (e.g. NixOS), `CMAKE_LIBRARY_ARCHITECTURE` can be empty
-        set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_DATAROOTDIR}")
+        set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
     endif()
     set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/cxxopts" CACHE STRING "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
     set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")
     set(project_config "${PROJECT_BINARY_DIR}/cxxopts-config.cmake")
     set(targets_export_name cxxopts-targets)
     set(PackagingTemplatesDir "${PROJECT_SOURCE_DIR}/packaging")
-
-
-    if(${CMAKE_VERSION} VERSION_GREATER "3.14")
-        set(OPTIONAL_ARCH_INDEPENDENT "ARCH_INDEPENDENT")
-    endif()
 
     # Generate the version, config and target files into the build directory.
     write_basic_package_version_file(

--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -154,6 +154,10 @@ function(cxxopts_install_logic)
     set(CPACK_DEBIAN_COMPRESSION_TYPE "xz")
 
     set(PKG_CONFIG_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc")
+    if(CXXOPTS_USE_UNICODE_HELP)
+        set(PKG_CONFIG_REQUIRES "icu-cu")
+        set(PKG_CONFIG_EXTRA_CFLAGS "-DCXXOPTS_USE_UNICODE")
+    endif()
     configure_file("${PackagingTemplatesDir}/pkgconfig.pc.in" "${PKG_CONFIG_FILE_NAME}" @ONLY)
     install(FILES "${PKG_CONFIG_FILE_NAME}"
             DESTINATION "${CMAKE_INSTALL_LIBDIR_ARCHIND}/pkgconfig"

--- a/cmake/cxxopts.cmake
+++ b/cmake/cxxopts.cmake
@@ -91,7 +91,7 @@ function(cxxopts_install_logic)
         string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
     else()
         # On some systems (e.g. NixOS), `CMAKE_LIBRARY_ARCHITECTURE` can be empty
-        set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
+        set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_DATAROOTDIR}")
     endif()
     set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/cxxopts" CACHE STRING "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
     set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")

--- a/packaging/pkgconfig.pc.in
+++ b/packaging/pkgconfig.pc.in
@@ -3,5 +3,6 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}

--- a/packaging/pkgconfig.pc.in
+++ b/packaging/pkgconfig.pc.in
@@ -5,4 +5,5 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Cflags: -I${includedir}
+Requires: @PKG_CONFIG_REQUIRES@
+Cflags: -I${includedir} @PKG_CONFIG_EXTRA_CFLAGS@


### PR DESCRIPTION
This little series fixes or improves a number of package issues:
  - the pkg-config file has an empty Description: field
  - the pkg-config file now has it's `URL` field set
  - On NixOS, using CMAKE_INSTALL_DATAROOTDIR will put files in the proper arch-independent location
  - the pkg-config file now has it's `Requires` field and Cflags correctly configured when ICU is used
  - the CMake files and pkg-config files are properly installed in arch-specific locations when ICU is used. Since ICU is a arch specific the packaging files are also arch specific when used with ICU

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/423)
<!-- Reviewable:end -->
