### PR TITLE
fix conflict with minwindef.h on windows

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -976,11 +976,11 @@ integer_parser(const std::string& text, T& value)
     US limit = 0;
     if (negative)
     {
-      limit = static_cast<US>(std::abs(static_cast<intmax_t>(std::numeric_limits<T>::min())));
+      limit = static_cast<US>(std::abs(static_cast<intmax_t>((std::numeric_limits<T>::min)())));
     }
     else
     {
-      limit = std::numeric_limits<T>::max();
+      limit = (std::numeric_limits<T>::max)();
     }
 
     if (base != 0 && result > limit / base)


### PR DESCRIPTION
wasn't able to use the latest version of the library because of this pesky macro-identifier bug

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/426)
<!-- Reviewable:end -->
