### PR TITLE
Add <limits> include to cxxopts.hpp

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -42,6 +42,7 @@ THE SOFTWARE.
 #include <vector>
 #include <algorithm>
 #include <locale>
+#include <limits>
 
 #ifdef CXXOPTS_NO_EXCEPTIONS
 #include <iostream>


### PR DESCRIPTION
Build fails with `external/cxxopts/include/cxxopts.hpp:515:29: error: ‘numeric_limits’ is not a member of ‘std’`.
Full log:
![wasmdec](https://github.com/jarro2783/cxxopts/assets/152059541/acc608e3-b17f-4670-b54f-ee563973183a)

I found the fix here: https://stackoverflow.com/questions/71296302/numeric-limits-is-not-a-member-of-std

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/427)
<!-- Reviewable:end -->
