### PR TITLE
Add missing header for gcc-15

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #ifndef CXXOPTS_HPP_INCLUDED
 #define CXXOPTS_HPP_INCLUDED
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <exception>


### PR DESCRIPTION
GCC-15 no longer includes \<cstdint\> implicitly.
https://gcc.gnu.org/gcc-15/porting_to.html

```
/var/tmp/portage/dev-libs/cxxopts-3.2.0-r1/work/cxxopts-3.2.0/include/cxxopts.hpp:123:3: error: ‘uint8_t’ does not name a type
  123 |   uint8_t major, minor, patch;
      |   ^~~~~~~
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/438)
<!-- Reviewable:end -->
