### PR TITLE
Add ParseResult::contains method

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -1743,6 +1743,12 @@ CXXOPTS_DIAGNOSTIC_POP
     return viter->second.count();
   }
 
+  bool
+  contains(const std::string& o) const
+  {
+    return static_cast<bool>(count(o));
+  }
+
   const OptionValue&
   operator[](const std::string& option) const
   {

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -89,6 +89,7 @@ TEST_CASE("Basic options", "[options]")
   auto result = options.parse(argc, actual_argv);
 
   CHECK(result.count("long") == 1);
+  CHECK(result.contains("long"));
   CHECK(result.count("s") == 1);
   CHECK(result.count("value") == 1);
   CHECK(result.count("a") == 1);
@@ -112,6 +113,8 @@ TEST_CASE("Basic options", "[options]")
   CHECK(arguments[2].key() == "value");
   CHECK(arguments[3].key() == "av");
 
+  CHECK(result.count("nothing") == 0);
+  CHECK_FALSE(result.contains("nothing"));
   CHECK_THROWS_AS(result["nothing"].as<std::string>(), cxxopts::exceptions::option_has_no_value);
 
   CHECK(options.program() == "tester");


### PR DESCRIPTION
Adds a method imitating C++20 std::map contains method for ParseResult. This makes certain syntax more concise:
```
    options.add_options()
    ...
        ("d,debug", "Enable debugging")
    ...    
    ;

    bool debug = result.contains("debug");
```

Obviously this is syntactic sugar for `static_cast<bool>(count())` but just like with `std::map` this is common enough of a use case to be worth adding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/440)
<!-- Reviewable:end -->
