### PR TITLE
C++17 std::optional test coverage fixups

### DIFF
--- a/test/options.cpp
+++ b/test/options.cpp
@@ -836,6 +836,7 @@ TEST_CASE("Optional value", "[optional]")
 
   SECTION("Available") {
     Argv av({
+      "available",
       "--int",
       "42",
       "--float",
@@ -853,13 +854,14 @@ TEST_CASE("Optional value", "[optional]")
     CHECK(result.as_optional<float>("float"));
     CHECK(result.as_optional<std::string>("string"));
 
-    CHECK(*result.as_optional<int>("int") == 42);
-    CHECK(*result.as_optional<float>("float") == 3.141);
-    CHECK(*result.as_optional<std::string>("string") == "Hello");
+    CHECK(result.as_optional<int>("int") == 42);
+    CHECK(result.as_optional<float>("float") == 3.141f);
+    CHECK(result.as_optional<std::string>("string") == "Hello");
   }
 
   SECTION("Unavailable") {
     Argv av({
+      "unavailable"
     });
 
     auto** argv = av.argv();


### PR DESCRIPTION
The unit tests were failing for me without these changes.

The first `Argv` argument should be the program name?

And use `std::optional<T>::operator==`

```
$ cmake -DCXXOPTS_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Release --fresh .. && make clean all test
...
Running tests...
Test project /home/nigels/dev/cxxopts/build
    Start 1: options
1/3 Test #1: options ..........................   Passed    0.00 sec
    Start 2: find-package-test
2/3 Test #2: find-package-test ................   Passed    6.40 sec
    Start 3: add-subdirectory-test
3/3 Test #3: add-subdirectory-test ............   Passed    6.39 sec

100% tests passed, 0 tests failed out of 3
```

And

```
$ test/options_test '[optional]' 
Filters: [optional]
===============================================================================
All tests passed (13 assertions in 2 test cases)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/446)
<!-- Reviewable:end -->
