### PR TITLE
C++17 std::filesystem::path support added

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -73,6 +73,12 @@ THE SOFTWARE.
 #      define CXXOPTS_HAS_OPTIONAL
 #    endif
 #  endif
+#  if __has_include(<filesystem>)
+#    include <filesystem>
+#    ifdef __cpp_lib_filesystem
+#      define CXXOPTS_HAS_FILESYSTEM
+#    endif
+#  endif
 #endif
 
 #define CXXOPTS_FALLTHROUGH
@@ -1071,6 +1077,15 @@ parse_value(const std::string& text, std::optional<T>& value)
   T result;
   parse_value(text, result);
   value = std::move(result);
+}
+#endif
+
+#ifdef CXXOPTS_HAS_FILESYSTEM
+inline
+void
+parse_value(const std::string& text, std::filesystem::path& value)
+{
+  value.assign(text);
 }
 #endif
 

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -732,6 +732,27 @@ TEST_CASE("std::optional", "[optional]") {
 }
 #endif
 
+#ifdef CXXOPTS_HAS_FILESYSTEM
+TEST_CASE("std::filesystem::path", "[path]") {
+  std::filesystem::path path;
+  cxxopts::Options options("path", " - tests path");
+  options.add_options()
+    ("path", "a path", cxxopts::value<std::filesystem::path>(path));
+
+  Argv av({"path", "--path", "Hello World.txt"});
+
+  auto** argv = av.argv();
+  auto argc = av.argc();
+
+  REQUIRE(path.empty());
+
+  options.parse(argc, argv);
+
+  REQUIRE(!path.empty());
+  CHECK(path == "Hello World.txt");
+}
+#endif
+
 TEST_CASE("Unrecognised options", "[options]") {
   cxxopts::Options options("unknown_options", " - test unknown options");
 

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -898,6 +898,60 @@ TEST_CASE("Optional value", "[optional]")
 }
 #endif
 
+#ifdef CXXOPTS_HAS_OPTIONAL
+TEST_CASE("std::filesystem::path value", "[path]")
+{
+  cxxopts::Options options("options", "query as std::fileystem::path");
+  options.add_options()
+    ("a", "Path", cxxopts::value<std::filesystem::path>())
+    ("b", "Path", cxxopts::value<std::filesystem::path>())
+    ("c", "Path", cxxopts::value<std::filesystem::path>())
+    ("d", "Path", cxxopts::value<std::filesystem::path>())
+    ("e", "Path", cxxopts::value<std::filesystem::path>())
+    ;
+
+  SECTION("Available") {
+    Argv av({
+      "available",
+      "-a", "hello.txt",
+      "-b", "C:\\Users\\JoeCitizen\\hello world.txt",
+      "-c", "/home/joecitzen/hello world.txt",
+      "-d", "../world.txt"
+    });
+
+    auto** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+
+    CHECK(result.as_optional<std::filesystem::path>("a"));
+    CHECK(result.as_optional<std::filesystem::path>("b"));
+    CHECK(result.as_optional<std::filesystem::path>("c"));
+    CHECK(result.as_optional<std::filesystem::path>("d"));
+    CHECK(!result.as_optional<std::filesystem::path>("e"));
+
+    CHECK(result.as_optional<std::filesystem::path>("a") == "hello.txt");
+    CHECK(result.as_optional<std::filesystem::path>("b") == "C:\\Users\\JoeCitizen\\hello world.txt");
+    CHECK(result.as_optional<std::filesystem::path>("c") == "/home/joecitzen/hello world.txt");
+    CHECK(result.as_optional<std::filesystem::path>("d") == "../world.txt");
+  }
+
+  SECTION("Unavailable") {
+    Argv av({
+      "unavailable"
+    });
+
+    auto** argv = av.argv();
+    auto argc = av.argc();
+
+    auto result = options.parse(argc, argv);
+
+    CHECK(!result.as_optional<std::filesystem::path>("a"));
+  }
+
+}
+#endif
+
 TEST_CASE("Initializer list with group", "[options]") {
   cxxopts::Options options("Initializer list group", " - test initializer list with group");
 


### PR DESCRIPTION
Main thing for supporting C++17 std::filesystem::path is the specialisation for `parse_value`.

Test coverage added.

```
$ test/options_test '[path]' 
Filters: [path]
===============================================================================
All tests passed (3 assertions in 1 test case)
```

For Issue #439

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/447)
<!-- Reviewable:end -->
