### PR TITLE
fix(test): make test C++ standard consistent with build config

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,8 @@ add_test(find-package-test ${CMAKE_CTEST_COMMAND}
     --build-makeprogram ${CMAKE_MAKE_PROGRAM}
     --build-options
     "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+    "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
     "-Dcxxopts_DIR=${PROJECT_BINARY_DIR}"
 )
@@ -46,6 +48,8 @@ add_test(add-subdirectory-test ${CMAKE_CTEST_COMMAND}
     --build-makeprogram ${CMAKE_MAKE_PROGRAM}
     --build-options
     "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+    "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 )
 

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 
 project(cxxopts-test)
 
-set(CMAKE_CXX_STANDARD   11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 add_subdirectory(../.. cxxopts EXCLUDE_FROM_ALL)
 
 add_executable(library-test "../../src/example.cpp")

--- a/test/find-package-test/CMakeLists.txt
+++ b/test/find-package-test/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 
 project(cxxopts-test)
 
-set(CMAKE_CXX_STANDARD   11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(cxxopts REQUIRED)
 
 add_executable(library-test "../../src/example.cpp")


### PR DESCRIPTION
Close #449
Inherit `CMAKE_CXX_STANDARD` and `CMAKE_CXX_EXTENSIONS` from source build config.
Maybe offtopic: ctest seems to face perf regression (tested on g++ 14.2.1).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/450)
<!-- Reviewable:end -->
