### PR TITLE
Fixes potential segmentation fault in edge cases.

### DIFF
--- a/include/cxxopts.hpp
+++ b/include/cxxopts.hpp
@@ -2519,7 +2519,7 @@ OptionParser::parse(int argc, const char* const* argv)
 
   std::vector<std::string> unmatched;
 
-  while (current != argc)
+  while (current < argc)
   {
     if (strcmp(argv[current], "--") == 0)
     {


### PR DESCRIPTION
Check for null pointer before accessing argv[current] in OptionParser::parse() to handle invalid argument scenarios that can occur with over-processed command line arguments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/465)
<!-- Reviewable:end -->
