### PR TITLE
docs: Add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Build Status](https://github.com/jarro2783/cxxopts/actions/workflows/cmake.yml/badge.svg)](https://github.com/jarro2783/cxxopts/actions/workflows/cmake.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/jarro2783/cxxopts/cmake.yml?label=build)](https://github.com/jarro2783/cxxopts/actions/workflows/cmake.yml)
 [![Conan](https://img.shields.io/conan/v/cxxopts)](https://conan.io/center/recipes/cxxopts)
 [![vcpkg](https://img.shields.io/vcpkg/v/cxxopts)](https://vcpkg.io/en/package/cxxopts)
 [![GitHub release](https://img.shields.io/github/v/release/jarro2783/cxxopts?label=github%20release)](https://github.com/jarro2783/cxxopts/releases)


### PR DESCRIPTION
This PR adds informative badges to the README:

- Shows availability via package managers
- Add weight to the maturity and quality of the library. Shows the actual usage via download stats ( awesome c++, brew download stats)
- Emphasize header-only, which is one of the selling point of the libarary

How it looks

<img width="888" height="391" alt="image" src="https://github.com/user-attachments/assets/09ed4dba-cc1c-407e-b2a5-4ca98b86358c" />

Let me know if you want to tweak some of this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarro2783/cxxopts/482)
<!-- Reviewable:end -->
